### PR TITLE
reject proof requests early for verifier-only instances

### DIFF
--- a/crates/server/src/http/v1/post_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/post_execution_proof_requests.rs
@@ -48,15 +48,16 @@ pub(crate) async fn post_execution_proof_requests(
     // before wasting resources on witness fetching.
     for proof_type in &proof_types {
         if let Some(zkvm) = state.zkvms.get(proof_type)
-            && matches!(zkvm, zkVMInstance::Verifier { .. }) {
-                debug!(
-                    %proof_type,
-                    "rejecting proof request: verifier-only instance"
-                );
-                return Err(ErrorResponse::bad_request(format!(
-                    "proof generation not supported for verifier-only zkvm '{proof_type}'"
-                )));
-            }
+            && matches!(zkvm, zkVMInstance::Verifier { .. })
+        {
+            debug!(
+                %proof_type,
+                "rejecting proof request: verifier-only instance"
+            );
+            return Err(ErrorResponse::bad_request(format!(
+                "proof generation not supported for verifier-only zkvm '{proof_type}'"
+            )));
+        }
     }
 
     let new_payload_request = NewPayloadRequest::<MainnetEthSpec>::from_ssz_bytes(&body)

--- a/crates/server/src/http/v1/post_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/post_execution_proof_requests.rs
@@ -47,8 +47,8 @@ pub(crate) async fn post_execution_proof_requests(
     // Reject proof generation requests for verifier-only instances early,
     // before wasting resources on witness fetching.
     for proof_type in &proof_types {
-        if let Some(zkvm) = state.zkvms.get(proof_type) {
-            if matches!(zkvm, zkVMInstance::Verifier { .. }) {
+        if let Some(zkvm) = state.zkvms.get(proof_type)
+            && matches!(zkvm, zkVMInstance::Verifier { .. }) {
                 debug!(
                     %proof_type,
                     "rejecting proof request: verifier-only instance"
@@ -57,7 +57,6 @@ pub(crate) async fn post_execution_proof_requests(
                     "proof generation not supported for verifier-only zkvm '{proof_type}'"
                 )));
             }
-        }
     }
 
     let new_payload_request = NewPayloadRequest::<MainnetEthSpec>::from_ssz_bytes(&body)

--- a/crates/server/src/http/v1/post_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/post_execution_proof_requests.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use axum::{Json, extract::State};
 use bytes::Bytes;
-use tracing::{info_span, instrument};
+use tracing::{debug, info_span, instrument};
 use zkboost_types::{
     Decode, MainnetEthSpec, NewPayloadRequest, ProofRequestQuery, ProofRequestResponse, TreeHash,
 };
@@ -14,7 +14,7 @@ use crate::{
         AppState,
         v1::{ErrorResponse, Query},
     },
-    proof::ProofServiceMessage,
+    proof::{ProofServiceMessage, zkvm::zkVMInstance},
 };
 
 #[instrument(skip_all)]
@@ -41,6 +41,22 @@ pub(crate) async fn post_execution_proof_requests(
             return Err(ErrorResponse::bad_request(format!(
                 "no zkVM configured for proof type '{proof_type}'"
             )));
+        }
+    }
+
+    // Reject proof generation requests for verifier-only instances early,
+    // before wasting resources on witness fetching.
+    for proof_type in &proof_types {
+        if let Some(zkvm) = state.zkvms.get(proof_type) {
+            if matches!(zkvm, zkVMInstance::Verifier { .. }) {
+                debug!(
+                    %proof_type,
+                    "rejecting proof request: verifier-only instance"
+                );
+                return Err(ErrorResponse::bad_request(format!(
+                    "proof generation not supported for verifier-only zkvm '{proof_type}'"
+                )));
+            }
         }
     }
 

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -79,10 +79,22 @@ impl zkBoostServer {
         let mut zkvms = HashMap::new();
         for zkvm_config in &config.zkvm {
             let instance = zkVMInstance::new(zkvm_config).await?;
+            let mode = match zkvm_config {
+                crate::config::zkVMConfig::Ere { .. } => "prover",
+                crate::config::zkVMConfig::Mock { .. } => "mock",
+                crate::config::zkVMConfig::Verifier { .. } => "verifier-only",
+            };
             info!(
                 proof_type = %zkvm_config.proof_type(),
+                mode,
                 "zkvm instance created"
             );
+            if matches!(zkvm_config, crate::config::zkVMConfig::Verifier { .. }) {
+                info!(
+                    proof_type = %zkvm_config.proof_type(),
+                    "verifier-only mode: proof generation requests will be rejected"
+                );
+            }
             zkvms.insert(zkvm_config.proof_type(), instance);
         }
         set_programs_loaded(zkvms.len());


### PR DESCRIPTION
## Summary

Verifier-only zkVM instances (`kind: verifier`) can only verify proofs received via gossip - they cannot generate proofs. Previously, proof generation requests to verifier-only instances were:
  1. Accepted by the HTTP handler
  2. Witness fetched from EL (expensive and wasteful)
  3. Failed silently at the worker dispatch layer (no worker exists)

This PR rejects proof requests early at the HTTP layer with a 400 Bad Request, before any witness fetching occurs.

## Changes

  - **Early rejection**: Return HTTP 400 for proof generation requests targeting verifier-only zkvms
  - **Startup logging**: Add `mode` field (prover/mock/verifier-only) to zkvm instance creation log
  - **Verifier-only info**: Log at startup that proof generation requests will be rejected
  - **Debug logging**: Log each rejected request at debug level

## Behavior

Startup log

```
INFO zkboost_server::server: zkvm instance created proof_type=ethrex-zisk mode="verifier-only"
INFO zkboost_server::server: verifier-only mode: proof generation requests will be rejected proof_type=ethrex-zisk
```

Per-request (debug level)
```
DEBUG post_execution_proof_requests: zkboost_server::http::v1::post_execution_proof_requests: rejecting proof request: verifier-only instance proof_type=ethrex-zisk
```