### PR TITLE
add trace contex, el headers and failure replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10876,14 +10876,21 @@ name = "zkboost-client"
 version = "0.9.0"
 dependencies = [
  "async-stream",
+ "axum",
  "bytes",
  "futures",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "reqwest",
  "reqwest-eventsource",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tokio-stream",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "url",
  "zkboost-types",
 ]

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ The following endpoints are available:
 | `GET`  | `/health`                                                      | Health check                                             |
 | `GET`  | `/metrics`                                                     | Prometheus metrics                                       |
 
+Proof events on the SSE stream are delivered at-least-once with latest-wins semantics:
+terminal results (completions and failures) that happened before subscribing are replayed
+from bounded caches, and a replayed stale failure may be followed by the completion of a
+retry that has already succeeded. Clients should treat the most recent terminal event per
+`(new_payload_request_root, proof_type)` as authoritative.
+
 See [openapi.json](openapi.json) for the full API specification ([rendered](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/eth-act/zkboost/master/openapi.json)).
 
 ## Observability

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ port = 3000
 # Ethereum execution layer JSON-RPC endpoint (required)
 el_endpoint = "http://localhost:8545"
 
+# Optional HTTP headers applied to every EL JSON-RPC request (e.g. authentication).
+# Header names are case-insensitive; names differing only in case are rejected.
+# [el_headers]
+# Authorization = "Bearer <token>"
+
 # Optional local EL chain config JSON file.
 # chain_config_path = "path/to/chain_config.json"
 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ The following endpoints are available:
 
 Proof events on the SSE stream are delivered at-least-once with latest-wins semantics:
 terminal results (completions and failures) that happened before subscribing are replayed
-from bounded caches, and a replayed stale failure may be followed by the completion of a
-retry that has already succeeded. Clients should treat the most recent terminal event per
+from bounded caches. Admitting a retry evicts its previous failure, although a concurrent
+subscription that already snapshotted that failure may still deliver it before the retry's
+terminal event. Clients should treat the most recent terminal event per
 `(new_payload_request_root, proof_type)` as authoritative.
 
 See [openapi.json](openapi.json) for the full API specification ([rendered](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/eth-act/zkboost/master/openapi.json)).

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -8,16 +8,40 @@ license.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = []
+otel = [
+    "dep:opentelemetry",
+    "dep:tracing",
+    "dep:tracing-opentelemetry",
+]
+
 [dependencies]
 async-stream.workspace = true
 bytes.workspace = true
 futures.workspace = true
+opentelemetry = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json"] }
 reqwest-eventsource.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio-stream.workspace = true
+tracing = { workspace = true, optional = true }
+tracing-opentelemetry = { workspace = true, optional = true }
 url.workspace = true
 
 zkboost-types.workspace = true
+
+[dev-dependencies]
+axum.workspace = true
+opentelemetry.workspace = true
+opentelemetry_sdk.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt"] }
+tracing.workspace = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber = { workspace = true, features = ["registry"] }
+
+[[test]]
+name = "otel_propagation"
+required-features = ["otel"]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -41,20 +41,7 @@
 //! # }
 //! ```
 
-#![warn(unused_crate_dependencies)]
-
-// Dev-dependencies are used by the integration tests, not the lib target; reference them here so
-// `unused_crate_dependencies` does not fire when compiling the lib's test harness.
-#[cfg(test)]
-mod dev_dependencies {
-    use axum as _;
-    use opentelemetry as _;
-    use opentelemetry_sdk as _;
-    use tokio as _;
-    use tracing as _;
-    use tracing_opentelemetry as _;
-    use tracing_subscriber as _;
-}
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod error;
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -8,6 +8,25 @@
 //! - [`get_proof`](zkBoostClient::get_proof) - download completed proof bytes
 //! - [`verify_proof`](zkBoostClient::verify_proof) - verify a proof against the server
 //!
+//! # Distributed tracing
+//!
+//! With the `otel` cargo feature enabled, every outbound request carries the current
+//! `tracing` span's W3C trace context (`traceparent`/`tracestate`), injected via the global
+//! OpenTelemetry propagator, so proofs requested from an instrumented caller join its
+//! distributed trace. Without the feature no OpenTelemetry dependency is pulled in and requests
+//! are sent unchanged.
+//!
+//! Note that the global propagator defaults to a no-op: the calling application must install
+//! one, e.g.
+//!
+//! ```ignore
+//! opentelemetry::global::set_text_map_propagator(
+//!     opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+//! );
+//! ```
+//!
+//! otherwise no `traceparent` header is emitted even with the feature enabled.
+//!
 //! # Example
 //!
 //! ```ignore
@@ -23,6 +42,19 @@
 //! ```
 
 #![warn(unused_crate_dependencies)]
+
+// Dev-dependencies are used by the integration tests, not the lib target; reference them here so
+// `unused_crate_dependencies` does not fire when compiling the lib's test harness.
+#[cfg(test)]
+mod dev_dependencies {
+    use axum as _;
+    use opentelemetry as _;
+    use opentelemetry_sdk as _;
+    use tokio as _;
+    use tracing as _;
+    use tracing_opentelemetry as _;
+    use tracing_subscriber as _;
+}
 
 pub mod error;
 
@@ -47,6 +79,43 @@ pub use {
 
 const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
 
+/// [`Injector`](opentelemetry::propagation::Injector) over HTTP headers, used to inject W3C trace
+/// context (`traceparent`/`tracestate`) into outbound requests.
+#[cfg(feature = "otel")]
+struct HeaderInjector<'a>(&'a mut reqwest::header::HeaderMap);
+
+#[cfg(feature = "otel")]
+impl opentelemetry::propagation::Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(name) = reqwest::header::HeaderName::from_bytes(key.as_bytes())
+            && let Ok(value) = reqwest::header::HeaderValue::from_str(&value)
+        {
+            self.0.insert(name, value);
+        }
+    }
+}
+
+/// Returns headers carrying the current `tracing` span's W3C trace context
+/// (`traceparent`/`tracestate`), injected via the global OpenTelemetry propagator.
+///
+/// Without the `otel` feature this returns an empty map, so requests are sent unchanged. With
+/// the feature, the map is still empty unless the application has installed a global text-map
+/// propagator (the OpenTelemetry default is a no-op).
+fn trace_context_headers() -> reqwest::header::HeaderMap {
+    #[cfg_attr(not(feature = "otel"), expect(unused_mut))]
+    let mut headers = reqwest::header::HeaderMap::new();
+    #[cfg(feature = "otel")]
+    {
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+        let context = tracing::Span::current().context();
+        opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(&context, &mut HeaderInjector(&mut headers));
+        });
+    }
+    headers
+}
+
 /// HTTP client for the zkboost Proof Node API.
 #[derive(Debug, Clone)]
 #[allow(non_camel_case_types)]
@@ -65,6 +134,9 @@ impl zkBoostClient {
     }
 
     /// Creates a new client with a custom [`reqwest::Client`].
+    ///
+    /// Use this to customize transport behavior, e.g. attach extra headers to every request via
+    /// [`reqwest::ClientBuilder::default_headers`] (for authenticated endpoints).
     pub fn with_http_client(endpoint: Url, http_client: reqwest::Client) -> Self {
         Self {
             endpoint,
@@ -93,6 +165,7 @@ impl zkBoostClient {
         let response = self
             .http_client
             .post(url)
+            .headers(trace_context_headers())
             .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM)
             .body(body.to_ssz())
             .send()
@@ -111,6 +184,9 @@ impl zkBoostClient {
         &self,
         filter_root: Option<Hash256>,
     ) -> impl Stream<Item = Result<ProofEvent, Error>> + Send + '_ {
+        // Capture the trace context eagerly so the subscription joins the span current at call
+        // time, not whichever span happens to be current when the stream is first polled.
+        let trace_headers = trace_context_headers();
         async_stream::try_stream! {
             let mut url = self.endpoint.join("/v1/execution_proof_requests")?;
             if let Some(new_payload_request_root) = filter_root {
@@ -118,7 +194,7 @@ impl zkBoostClient {
                     .append_pair("new_payload_request_root", &new_payload_request_root.to_string());
             }
 
-            let builder = self.http_client.get(url);
+            let builder = self.http_client.get(url).headers(trace_headers);
             let mut es = EventSource::new(builder)
                 .map_err(|e| Error::Sse(format!("failed to create event source: {e}")))?;
 
@@ -150,7 +226,8 @@ impl zkBoostClient {
             "/v1/execution_proofs/{new_payload_request_root}/{proof_type}"
         ))?;
 
-        let response = error_for_status(self.http_client.get(url).send().await?).await?;
+        let request = self.http_client.get(url).headers(trace_context_headers());
+        let response = error_for_status(request.send().await?).await?;
         Ok(response.bytes().await?)
     }
 
@@ -176,6 +253,7 @@ impl zkBoostClient {
         let response = self
             .http_client
             .post(url)
+            .headers(trace_context_headers())
             .header(CONTENT_TYPE, APPLICATION_OCTET_STREAM)
             .body(body.to_ssz())
             .send()

--- a/crates/client/tests/otel_propagation.rs
+++ b/crates/client/tests/otel_propagation.rs
@@ -1,0 +1,102 @@
+//! Tests that outbound client requests carry the calling span's W3C trace context
+//! (`traceparent`) when the `otel` feature is enabled.
+
+use std::sync::{Arc, Mutex};
+
+use axum::{Router, extract::State, http::HeaderMap};
+use opentelemetry::trace::{TraceContextExt, TracerProvider};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::SdkTracerProvider};
+use tokio_stream::StreamExt;
+use tracing::Instrument;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::layer::SubscriberExt;
+use zkboost_client::{Hash256, ProofType, zkBoostClient};
+
+/// `traceparent` header values captured by the local server, one per request received.
+type CapturedTraceparents = Arc<Mutex<Vec<Option<String>>>>;
+
+async fn capture_traceparent(State(captured): State<CapturedTraceparents>, headers: HeaderMap) {
+    let traceparent = headers
+        .get("traceparent")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    captured.lock().unwrap().push(traceparent);
+}
+
+/// Extracts the trace id from a W3C `traceparent` header (`00-<trace_id>-<span_id>-<flags>`).
+fn trace_id_of(traceparent: &str) -> &str {
+    traceparent
+        .split('-')
+        .nth(1)
+        .expect("traceparent should have a trace id field")
+}
+
+/// Sends requests from within tracing spans and asserts each request arrives with a
+/// `traceparent` header carrying the active span's trace id.
+#[tokio::test]
+async fn test_outbound_requests_carry_active_span_trace_context() {
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    let provider = SdkTracerProvider::builder().build();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_opentelemetry::OpenTelemetryLayer::new(provider.tracer("test")),
+    );
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    // Local server capturing the `traceparent` header of every request.
+    let captured = CapturedTraceparents::default();
+    let app = Router::new()
+        .fallback(capture_traceparent)
+        .with_state(captured.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let client = zkBoostClient::new(endpoint.parse().unwrap());
+
+    // Unary request: `get_proof` awaited inside a span.
+    let unary_span = tracing::info_span!("unary_caller");
+    let unary_trace_id = unary_span
+        .context()
+        .span()
+        .span_context()
+        .trace_id()
+        .to_string();
+    assert_ne!(
+        unary_trace_id, "00000000000000000000000000000000",
+        "span should carry a valid OpenTelemetry context"
+    );
+    client
+        .get_proof(Hash256::ZERO, ProofType::RethZisk)
+        .instrument(unary_span)
+        .await
+        .unwrap();
+
+    // SSE subscription: the context is captured when `subscribe_proof_events` is called, even
+    // though the request is only sent once the stream is polled (outside the span, here). The
+    // plain 200 response fails SSE content-type validation, which is fine: the request has
+    // already reached the server with its headers by then.
+    let sse_span = tracing::info_span!("sse_caller");
+    let sse_trace_id = sse_span
+        .context()
+        .span()
+        .span_context()
+        .trace_id()
+        .to_string();
+    let stream = {
+        let _entered = sse_span.enter();
+        client.subscribe_proof_events(None)
+    };
+    let mut stream = std::pin::pin!(stream);
+    let _ = stream.next().await;
+
+    let captured = captured.lock().unwrap();
+    assert_eq!(captured.len(), 2);
+    let unary_traceparent = captured[0]
+        .as_deref()
+        .expect("get_proof should send traceparent");
+    assert_eq!(trace_id_of(unary_traceparent), unary_trace_id);
+    let sse_traceparent = captured[1]
+        .as_deref()
+        .expect("subscribe should send traceparent");
+    assert_eq!(trace_id_of(sse_traceparent), sse_trace_id);
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -81,3 +81,7 @@ opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
 # local
 zkboost-client.workspace = true
+
+[[test]]
+name = "otel_request_span"
+required-features = ["otel"]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -77,6 +77,7 @@ zkboost-types.workspace = true
 
 [dev-dependencies]
 futures.workspace = true
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
 # local
 zkboost-client.workspace = true

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,14 +1,15 @@
 //! Configuration types.
 
 use std::{
-    collections::HashSet,
-    fs,
+    collections::{HashMap, HashSet},
+    fmt, fs,
     path::{Path, PathBuf},
     time::Duration,
 };
 
 use anyhow::{Context, ensure};
 use ere_verifier::zkVMKind;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use zkboost_types::ProofType;
@@ -59,13 +60,19 @@ fn default_dashboard_retention() -> usize {
 }
 
 /// Unified configuration for the zkboost proof node.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `Debug` is implemented manually so `el_headers` values (which typically carry
+/// credentials) are redacted.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Config {
     /// HTTP server port.
     #[serde(default = "default_port")]
     pub port: u16,
     /// EL endpoint for witness fetching.
     pub el_endpoint: Url,
+    /// Optional HTTP headers applied to every EL JSON-RPC request (e.g. authentication).
+    #[serde(default)]
+    pub el_headers: HashMap<String, String>,
     /// Optional path to a local execution-layer chain config JSON file.
     #[serde(default)]
     pub chain_config_path: Option<PathBuf>,
@@ -85,6 +92,33 @@ pub struct Config {
     pub zkvm: Vec<zkVMConfig>,
 }
 
+impl fmt::Debug for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Formats the `el_headers` map with every value replaced by `<redacted>`.
+        struct RedactedHeaders<'a>(&'a HashMap<String, String>);
+
+        impl fmt::Debug for RedactedHeaders<'_> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_map()
+                    .entries(self.0.keys().map(|name| (name, "<redacted>")))
+                    .finish()
+            }
+        }
+
+        f.debug_struct("Config")
+            .field("port", &self.port)
+            .field("el_endpoint", &self.el_endpoint)
+            .field("el_headers", &RedactedHeaders(&self.el_headers))
+            .field("chain_config_path", &self.chain_config_path)
+            .field("witness_timeout_secs", &self.witness_timeout_secs)
+            .field("proof_cache_size", &self.proof_cache_size)
+            .field("witness_cache_size", &self.witness_cache_size)
+            .field("dashboard", &self.dashboard)
+            .field("zkvm", &self.zkvm)
+            .finish()
+    }
+}
+
 impl Config {
     /// Load configuration from a TOML file at the given path.
     pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
@@ -94,11 +128,36 @@ impl Config {
         Ok(config)
     }
 
+    /// Builds the header map applied to every EL JSON-RPC request from `el_headers`.
+    pub fn el_header_map(&self) -> anyhow::Result<HeaderMap> {
+        let mut headers = HeaderMap::with_capacity(self.el_headers.len());
+        for (name, value) in &self.el_headers {
+            let name: HeaderName = name
+                .parse()
+                .with_context(|| format!("invalid el_headers header name: {name}"))?;
+            let mut value: HeaderValue = value
+                .parse()
+                .with_context(|| format!("invalid el_headers value for header: {name}"))?;
+            // Header values typically carry credentials; mark them sensitive so `Debug`
+            // formatting of the header map redacts them.
+            value.set_sensitive(true);
+            // `el_headers` is a case-sensitive TOML map while header names are
+            // case-insensitive, so keys differing only in case would otherwise collapse
+            // here nondeterministically (HashMap iteration order decides which one wins).
+            ensure!(
+                headers.insert(&name, value).is_none(),
+                "duplicate el_headers header (names are case-insensitive): {name}"
+            );
+        }
+        Ok(headers)
+    }
+
     fn validate(&self) -> anyhow::Result<()> {
         ensure!(
             !self.zkvm.is_empty(),
             "at least one [[zkvm]] entry is required"
         );
+        self.el_header_map()?;
         ensure!(self.proof_cache_size > 0, "proof_cache_size must be > 0");
         ensure!(
             self.witness_cache_size > 0,
@@ -408,6 +467,115 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn test_el_headers_default_empty() {
+        let toml = r#"
+            el_endpoint = "http://localhost:8545"
+            [[zkvm]]
+            kind = "mock"
+            proof_type = "reth-sp1"
+        "#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        assert!(config.el_headers.is_empty());
+        assert!(config.el_header_map().unwrap().is_empty());
+        config.validate().unwrap();
+    }
+
+    #[test]
+    fn test_el_headers_parsed() {
+        let toml = r#"
+            el_endpoint = "http://localhost:8545"
+            [el_headers]
+            Authorization = "Bearer secret"
+            "X-Custom" = "1"
+            [[zkvm]]
+            kind = "mock"
+            proof_type = "reth-sp1"
+        "#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        config.validate().unwrap();
+        let headers = config.el_header_map().unwrap();
+        assert_eq!(headers.len(), 2);
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer secret");
+        assert_eq!(headers.get("x-custom").unwrap(), "1");
+    }
+
+    #[test]
+    fn test_el_headers_values_marked_sensitive() {
+        let toml = r#"
+            el_endpoint = "http://localhost:8545"
+            [el_headers]
+            Authorization = "Bearer secret"
+            [[zkvm]]
+            kind = "mock"
+            proof_type = "reth-sp1"
+        "#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        let headers = config.el_header_map().unwrap();
+        assert!(headers.get("authorization").unwrap().is_sensitive());
+    }
+
+    #[test]
+    fn test_config_debug_redacts_el_header_values() {
+        let toml = r#"
+            el_endpoint = "http://localhost:8545"
+            [el_headers]
+            Authorization = "Bearer secret"
+            [[zkvm]]
+            kind = "mock"
+            proof_type = "reth-sp1"
+        "#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        let debug = format!("{config:?}");
+        assert!(debug.contains("Authorization"), "{debug}");
+        assert!(debug.contains("<redacted>"), "{debug}");
+        assert!(!debug.contains("Bearer secret"), "{debug}");
+    }
+
+    #[test]
+    fn test_el_headers_case_duplicate_rejected() {
+        let toml = r#"
+            el_endpoint = "http://localhost:8545"
+            [el_headers]
+            Authorization = "Bearer secret"
+            authorization = "Bearer other"
+            [[zkvm]]
+            kind = "mock"
+            proof_type = "reth-sp1"
+        "#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("duplicate el_headers header"), "{error}");
+    }
+
+    #[test]
+    fn test_el_headers_invalid_name_rejected() {
+        let toml = r#"
+            el_endpoint = "http://localhost:8545"
+            [el_headers]
+            "bad header" = "value"
+            [[zkvm]]
+            kind = "mock"
+            proof_type = "reth-sp1"
+        "#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_el_headers_invalid_value_rejected() {
+        let toml = r#"
+            el_endpoint = "http://localhost:8545"
+            [el_headers]
+            Authorization = "bad\nvalue"
+            [[zkvm]]
+            kind = "mock"
+            proof_type = "reth-sp1"
+        "#;
+        let config: Config = toml_edit::de::from_str(toml).unwrap();
+        assert!(config.validate().is_err());
     }
 
     #[test]

--- a/crates/server/src/el_client.rs
+++ b/crates/server/src/el_client.rs
@@ -3,6 +3,7 @@
 
 use alloy_genesis::ChainConfig as AlloyChainConfig;
 use alloy_rpc_types_debug::ExecutionWitness;
+use anyhow::Context;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use url::Url;
 use zkboost_types::Hash256;
@@ -15,12 +16,13 @@ pub struct ElClient {
 }
 
 impl ElClient {
-    /// Create a new EL client.
-    pub fn new(url: Url) -> Self {
-        Self {
-            url,
-            http_client: reqwest::Client::new(),
-        }
+    /// Create a new EL client. `default_headers` are applied to every request.
+    pub fn new(url: Url, default_headers: reqwest::header::HeaderMap) -> anyhow::Result<Self> {
+        let http_client = reqwest::Client::builder()
+            .default_headers(default_headers)
+            .build()
+            .context("build EL HTTP client")?;
+        Ok(Self { url, http_client })
     }
 
     /// Return url of the EL client.

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -22,7 +22,7 @@ use crate::{
     chain_config::BlobParams,
     dashboard::{DashboardEvent, DashboardState},
     metrics::http_metrics_middleware,
-    proof::{ProofServiceMessage, zkvm::zkVMInstance},
+    proof::{FailureCache, ProofServiceMessage, zkvm::zkVMInstance},
 };
 
 mod dashboard;
@@ -34,6 +34,7 @@ pub(crate) struct AppState {
     pub(crate) blob_params: BlobParams,
     pub(crate) zkvms: Arc<HashMap<ProofType, zkVMInstance>>,
     pub(crate) proof_cache: Arc<RwLock<LruCache<(Hash256, ProofType), Bytes>>>,
+    pub(crate) failure_cache: FailureCache,
     pub(crate) metrics: PrometheusHandle,
     pub(crate) dashboard: Option<Arc<RwLock<DashboardState>>>,
     pub(crate) proof_service_tx: mpsc::Sender<ProofServiceMessage>,
@@ -48,6 +49,7 @@ impl AppState {
         blob_params: BlobParams,
         zkvms: Arc<HashMap<ProofType, zkVMInstance>>,
         proof_cache: Arc<RwLock<LruCache<(Hash256, ProofType), Bytes>>>,
+        failure_cache: FailureCache,
         metrics: PrometheusHandle,
         dashboard: Option<Arc<RwLock<DashboardState>>>,
         proof_service_tx: mpsc::Sender<ProofServiceMessage>,
@@ -58,6 +60,7 @@ impl AppState {
             blob_params,
             zkvms,
             proof_cache,
+            failure_cache,
             metrics,
             dashboard,
             proof_service_tx,
@@ -187,6 +190,7 @@ pub(crate) mod tests {
         let zkvms = Arc::new(HashMap::from_iter([(proof_type, zkvm)]));
 
         let proof_cache = Arc::new(RwLock::new(LruCache::new(NonZeroUsize::new(128).unwrap())));
+        let failure_cache = Arc::new(RwLock::new(LruCache::new(NonZeroUsize::new(128).unwrap())));
 
         let metrics = PrometheusBuilder::new().build_recorder().handle();
         let dashboard = Arc::new(RwLock::new(DashboardState::new(vec![proof_type], 256))).into();
@@ -199,6 +203,7 @@ pub(crate) mod tests {
             blob_params,
             zkvms,
             proof_cache,
+            failure_cache,
             metrics,
             dashboard,
             proof_service_tx,

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -78,6 +78,9 @@ fn make_request_span(request: &axum::http::Request<axum::body::Body>) -> tracing
         method = %request.method(),
         uri = %request.uri(),
         version = ?request.version(),
+        // Recorded only with the `otel` feature enabled, so the log format of default-feature
+        // builds is unchanged.
+        otel.kind = tracing::field::Empty,
     );
     #[cfg(feature = "otel")]
     {
@@ -89,6 +92,14 @@ fn make_request_span(request: &axum::http::Request<axum::body::Body>) -> tracing
         // Fails only when the OpenTelemetry layer is not installed (no OTLP endpoint
         // configured), in which case there is no trace to join.
         let _ = span.set_parent(parent);
+        span.record("otel.kind", "server");
+        // OpenTelemetry HTTP semantic-convention attributes. Set as OTLP-only attributes
+        // (not tracing fields) so they are exported without duplicating the log fields above.
+        span.set_attribute("http.request.method", request.method().to_string());
+        span.set_attribute("url.path", request.uri().path().to_owned());
+        if let Some(query) = request.uri().query() {
+            span.set_attribute("url.query", query.to_owned());
+        }
     }
     span
 }
@@ -211,69 +222,10 @@ pub(crate) mod tests {
         assert_eq!(response.status(), 200);
     }
 
-    /// Sends a request carrying a W3C `traceparent` header and asserts the exported `request`
-    /// span joins the caller's trace: same trace id, parented under the caller's span id.
-    #[cfg(feature = "otel")]
-    #[tokio::test]
-    async fn test_request_span_joins_remote_trace_context() {
-        use opentelemetry::trace::TracerProvider;
-        use opentelemetry_sdk::{
-            propagation::TraceContextPropagator,
-            trace::{InMemorySpanExporter, SdkTracerProvider},
-        };
-        use tracing_subscriber::layer::SubscriberExt;
-
-        const TRACE_ID: &str = "0af7651916cd43dd8448eb211c80319c";
-        const PARENT_SPAN_ID: &str = "b7ad6b7169203331";
-
-        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
-        let exporter = InMemorySpanExporter::default();
-        let provider = SdkTracerProvider::builder()
-            .with_simple_exporter(exporter.clone())
-            .build();
-        // Warm the `request` span callsite before installing the subscriber, so its interest
-        // cannot be mid-registration on a parallel test thread (which could leave a stale
-        // `never` interest cached after our subscriber rebuilds it).
-        let _ = super::make_request_span(&Request::builder().body(Body::empty()).unwrap());
-        let subscriber = tracing_subscriber::registry().with(
-            tracing_opentelemetry::OpenTelemetryLayer::new(provider.tracer("test")),
-        );
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        let state = mock_app_state().await;
-        // Parallel tests hitting the same callsite with no subscriber can transiently poison
-        // the global callsite interest cache, so rebuild and retry before declaring failure.
-        let mut request_span = None;
-        for _ in 0..5 {
-            tracing::callsite::rebuild_interest_cache();
-            let response = router(state.clone())
-                .oneshot(
-                    Request::builder()
-                        .uri("/v1/proof_types")
-                        .header("traceparent", format!("00-{TRACE_ID}-{PARENT_SPAN_ID}-01"))
-                        .body(Body::empty())
-                        .unwrap(),
-                )
-                .await
-                .unwrap();
-            assert_eq!(response.status(), 200);
-            // The request span stays open until the response body is fully consumed.
-            axum::body::to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap();
-
-            provider.force_flush().unwrap();
-            let spans = exporter.get_finished_spans().unwrap();
-            if let Some(span) = spans.iter().find(|span| span.name == "request") {
-                request_span = Some(span.clone());
-                break;
-            }
-        }
-
-        let request_span = request_span.expect("request span should be exported");
-        assert_eq!(request_span.span_context.trace_id().to_string(), TRACE_ID);
-        assert_eq!(request_span.parent_span_id.to_string(), PARENT_SPAN_ID);
-    }
+    // The `otel` request-span propagation test lives in its own integration-test binary
+    // (`tests/otel_request_span.rs`): it needs a tracing subscriber that observes spans created
+    // on other tasks, and sharing a process with parallel tests poisons the global callsite
+    // interest cache.
 
     #[tokio::test]
     async fn test_unknown_route_returns_json_404() {

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -67,11 +67,37 @@ impl AppState {
     }
 }
 
+/// Creates the tracing span for an incoming HTTP request.
+///
+/// With the `otel` feature enabled, W3C trace context (`traceparent`/`tracestate`) is extracted
+/// from the request headers and set as the span's parent, so spans created while handling the
+/// request join the caller's distributed trace. Without the feature this only creates the span.
+fn make_request_span(request: &axum::http::Request<axum::body::Body>) -> tracing::Span {
+    let span = tracing::info_span!(
+        "request",
+        method = %request.method(),
+        uri = %request.uri(),
+        version = ?request.version(),
+    );
+    #[cfg(feature = "otel")]
+    {
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+        let parent = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&crate::otel::HeaderExtractor(request.headers()))
+        });
+        // Fails only when the OpenTelemetry layer is not installed (no OTLP endpoint
+        // configured), in which case there is no trace to join.
+        let _ = span.set_parent(parent);
+    }
+    span
+}
+
 /// Builds the Axum router with all endpoints and middleware.
 pub(crate) fn router(state: Arc<AppState>) -> Router {
     let api_middleware = ServiceBuilder::new()
         .layer(middleware::from_fn(http_metrics_middleware))
-        .layer(TraceLayer::new_for_http())
+        .layer(TraceLayer::new_for_http().make_span_with(make_request_span))
         .layer(CatchPanicLayer::new())
         .layer(DefaultBodyLimit::max(1 << 30));
 
@@ -183,6 +209,70 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), 200);
+    }
+
+    /// Sends a request carrying a W3C `traceparent` header and asserts the exported `request`
+    /// span joins the caller's trace: same trace id, parented under the caller's span id.
+    #[cfg(feature = "otel")]
+    #[tokio::test]
+    async fn test_request_span_joins_remote_trace_context() {
+        use opentelemetry::trace::TracerProvider;
+        use opentelemetry_sdk::{
+            propagation::TraceContextPropagator,
+            trace::{InMemorySpanExporter, SdkTracerProvider},
+        };
+        use tracing_subscriber::layer::SubscriberExt;
+
+        const TRACE_ID: &str = "0af7651916cd43dd8448eb211c80319c";
+        const PARENT_SPAN_ID: &str = "b7ad6b7169203331";
+
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        // Warm the `request` span callsite before installing the subscriber, so its interest
+        // cannot be mid-registration on a parallel test thread (which could leave a stale
+        // `never` interest cached after our subscriber rebuilds it).
+        let _ = super::make_request_span(&Request::builder().body(Body::empty()).unwrap());
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_opentelemetry::OpenTelemetryLayer::new(provider.tracer("test")),
+        );
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let state = mock_app_state().await;
+        // Parallel tests hitting the same callsite with no subscriber can transiently poison
+        // the global callsite interest cache, so rebuild and retry before declaring failure.
+        let mut request_span = None;
+        for _ in 0..5 {
+            tracing::callsite::rebuild_interest_cache();
+            let response = router(state.clone())
+                .oneshot(
+                    Request::builder()
+                        .uri("/v1/proof_types")
+                        .header("traceparent", format!("00-{TRACE_ID}-{PARENT_SPAN_ID}-01"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), 200);
+            // The request span stays open until the response body is fully consumed.
+            axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+
+            provider.force_flush().unwrap();
+            let spans = exporter.get_finished_spans().unwrap();
+            if let Some(span) = spans.iter().find(|span| span.name == "request") {
+                request_span = Some(span.clone());
+                break;
+            }
+        }
+
+        let request_span = request_span.expect("request span should be exported");
+        assert_eq!(request_span.span_context.trace_id().to_string(), TRACE_ID);
+        assert_eq!(request_span.parent_span_id.to_string(), PARENT_SPAN_ID);
     }
 
     #[tokio::test]

--- a/crates/server/src/http/v1/get_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/get_execution_proof_requests.rs
@@ -12,6 +12,15 @@ use zkboost_types::{ProofComplete, ProofEvent, ProofEventQuery};
 
 use crate::http::{AppState, v1::Query};
 
+/// SSE endpoint handler for `GET /v1/execution_proof_requests`.
+///
+/// Event delivery is at-least-once with latest-wins semantics. When subscribing with a
+/// `new_payload_request_root`, terminal results (completions and failures) already in the
+/// caches are replayed so events broadcast before the subscription are not lost. Replay can
+/// race a concurrent retry: a stale `proof_failure` may be delivered before the
+/// `proof_complete` of a retry that has already succeeded (a completion evicts the cached
+/// failure, but a replay that started earlier can still emit it). Subscribers must treat the
+/// most recent terminal event per `(new_payload_request_root, proof_type)` as authoritative.
 #[instrument(skip_all)]
 pub(crate) async fn get_execution_proof_requests(
     State(state): State<Arc<AppState>>,
@@ -23,21 +32,31 @@ pub(crate) async fn get_execution_proof_requests(
 
     let merged: Pin<Box<dyn Stream<Item = Result<Event, Infallible>> + Send>> =
         if let Some(new_payload_request_root) = params.new_payload_request_root {
-            // Emit already-completed proofs from cache so the client does not miss events that
-            // completed before subscribing.
+            // Emit already-terminal results from the caches so the client does not miss events
+            // that completed or failed before subscribing.
             let catch_up_events = {
-                let cache = state.proof_cache.read().await;
-                cache
-                    .iter()
-                    .filter(|((cache, _), _)| *cache == new_payload_request_root)
-                    .map(|((new_payload_request_root, proof_type), _)| {
-                        ProofComplete {
-                            new_payload_request_root: *new_payload_request_root,
-                            proof_type: *proof_type,
-                        }
-                        .into()
-                    })
-                    .collect::<Vec<_>>()
+                let mut events: Vec<ProofEvent> = {
+                    let cache = state.proof_cache.read().await;
+                    cache
+                        .iter()
+                        .filter(|((root, _), _)| *root == new_payload_request_root)
+                        .map(|((new_payload_request_root, proof_type), _)| {
+                            ProofComplete {
+                                new_payload_request_root: *new_payload_request_root,
+                                proof_type: *proof_type,
+                            }
+                            .into()
+                        })
+                        .collect()
+                };
+                let failures = state.failure_cache.read().await;
+                events.extend(
+                    failures
+                        .iter()
+                        .filter(|((root, _), _)| *root == new_payload_request_root)
+                        .map(|(_, failure)| failure.clone().into()),
+                );
+                events
             };
             let catch_up_stream = tokio_stream::iter(catch_up_events);
             let filtered = catch_up_stream
@@ -61,8 +80,12 @@ fn to_axum_event(proof_event: ProofEvent) -> Event {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use axum::{Router, body::Body, http::Request, routing::get};
+    use tokio_stream::StreamExt;
     use tower::ServiceExt;
+    use zkboost_types::{FailureReason, Hash256, ProofFailure, ProofType};
 
     use crate::http::{tests::mock_app_state, v1::get_execution_proof_requests};
 
@@ -92,5 +115,56 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(content_type.contains("text/event-stream"));
+    }
+
+    /// A subscriber arriving after a proof failed still receives the failure, replayed from
+    /// the failure cache with the same event shape as the live broadcast.
+    #[tokio::test]
+    async fn test_subscribe_after_failure_replays_failure() {
+        // Arrange: a terminal failure cached before anyone subscribes.
+        let state = mock_app_state().await;
+        let root = Hash256::repeat_byte(0xab);
+        let failure = ProofFailure {
+            new_payload_request_root: root,
+            proof_type: ProofType::RethZisk,
+            reason: FailureReason::ProvingError,
+            error: "proving exploded".to_owned(),
+        };
+        state
+            .failure_cache
+            .write()
+            .await
+            .put((root, ProofType::RethZisk), failure.clone());
+
+        // Act: subscribe filtered on the failed request's root.
+        let response = Router::new()
+            .route(
+                "/v1/execution_proof_requests",
+                get(get_execution_proof_requests),
+            )
+            .with_state(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/v1/execution_proof_requests?new_payload_request_root={root}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+
+        // Assert: the first SSE frame is the replayed failure event.
+        let mut body = response.into_body().into_data_stream();
+        let frame = tokio::time::timeout(Duration::from_secs(5), body.next())
+            .await
+            .expect("catch-up event should arrive immediately")
+            .expect("stream should not end")
+            .unwrap();
+        let text = String::from_utf8(frame.to_vec()).unwrap();
+        assert!(text.contains("event: proof_failure"), "{text}");
+        let (_, expected_data) = zkboost_types::ProofEvent::ProofFailure(failure).to_parts();
+        assert!(text.contains(&expected_data), "{text}");
     }
 }

--- a/crates/server/src/http/v1/get_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/get_execution_proof_requests.rs
@@ -17,10 +17,10 @@ use crate::http::{AppState, v1::Query};
 /// Event delivery is at-least-once with latest-wins semantics. When subscribing with a
 /// `new_payload_request_root`, terminal results (completions and failures) already in the
 /// caches are replayed so events broadcast before the subscription are not lost. Replay can
-/// race a concurrent retry: a stale `proof_failure` may be delivered before the
-/// `proof_complete` of a retry that has already succeeded (a completion evicts the cached
-/// failure, but a replay that started earlier can still emit it). Subscribers must treat the
-/// most recent terminal event per `(new_payload_request_root, proof_type)` as authoritative.
+/// race a concurrent retry: admission evicts the prior cached failure, but a subscription that
+/// snapshotted it just before admission may still deliver that stale `proof_failure` before the
+/// retry's terminal event. Subscribers must treat the most recent terminal event per
+/// `(new_payload_request_root, proof_type)` as authoritative.
 #[instrument(skip_all)]
 pub(crate) async fn get_execution_proof_requests(
     State(state): State<Arc<AppState>>,

--- a/crates/server/src/otel.rs
+++ b/crates/server/src/otel.rs
@@ -2,7 +2,7 @@
 
 use std::env;
 
-use opentelemetry::trace::TracerProvider;
+use opentelemetry::{propagation::Extractor, trace::TracerProvider};
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::{
     Resource,
@@ -14,6 +14,20 @@ use tracing_subscriber::Registry;
 
 /// Type alias for the OpenTelemetry tracing layer.
 pub type OtelLayer = OpenTelemetryLayer<Registry, SdkTracer>;
+
+/// [`Extractor`] over HTTP headers, used to extract W3C trace context
+/// (`traceparent`/`tracestate`) from incoming requests.
+pub(crate) struct HeaderExtractor<'a>(pub(crate) &'a axum::http::HeaderMap);
+
+impl Extractor for HeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|value| value.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|key| key.as_str()).collect()
+    }
+}
 
 /// Initializes OpenTelemetry tracing if `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Returns a provider
 /// handle for explicit shutdown and an optional layer to attach to the tracing subscriber.

--- a/crates/server/src/proof.rs
+++ b/crates/server/src/proof.rs
@@ -61,9 +61,14 @@ struct PendingRequest {
     span: Span,
 }
 
+/// Bounded cache of terminal proof failures, replayed to SSE subscribers that subscribe after
+/// the live `proof_failure` event was broadcast (mirroring the completed-proof cache).
+pub(crate) type FailureCache = Arc<RwLock<LruCache<(Hash256, ProofType), ProofFailure>>>;
+
 /// Manages proof lifecycle: pending, enqueued, and completed proof requests.
 pub(crate) struct ProofService {
     proof_cache: Arc<RwLock<LruCache<(Hash256, ProofType), Bytes>>>,
+    failure_cache: FailureCache,
     proof_event_tx: broadcast::Sender<ProofEvent>,
     witness_service_tx: mpsc::Sender<WitnessServiceMessage>,
     dashboard_service_tx: mpsc::Sender<DashboardMessage>,
@@ -75,12 +80,14 @@ impl ProofService {
     /// Creates a new proof service with the given dependencies.
     pub(crate) fn new(
         proof_cache: Arc<RwLock<LruCache<(Hash256, ProofType), Bytes>>>,
+        failure_cache: FailureCache,
         proof_event_tx: broadcast::Sender<ProofEvent>,
         witness_service_tx: mpsc::Sender<WitnessServiceMessage>,
         dashboard_service_tx: mpsc::Sender<DashboardMessage>,
     ) -> Self {
         Self {
             proof_cache,
+            failure_cache,
             proof_event_tx,
             witness_service_tx,
             dashboard_service_tx,
@@ -141,6 +148,12 @@ impl ProofService {
                     .write()
                     .await
                     .put((new_payload_request_root, proof_type), proof);
+                // A retried request can succeed after an earlier failure; drop the stale
+                // failure so subscribers are not replayed both outcomes.
+                self.failure_cache
+                    .write()
+                    .await
+                    .pop(&(new_payload_request_root, proof_type));
                 let _ = self.proof_event_tx.send(
                     ProofComplete {
                         new_payload_request_root,
@@ -158,7 +171,8 @@ impl ProofService {
                     FailureReason::ProvingError,
                     error,
                     duration,
-                );
+                )
+                .await;
             }
             ProofResult::Timeout => {
                 error!(%block_hash, block_number, %proof_type, "proving timed out");
@@ -171,7 +185,8 @@ impl ProofService {
                         duration.as_secs_f64()
                     ),
                     duration,
-                );
+                )
+                .await;
             }
         }
 
@@ -259,7 +274,8 @@ impl ProofService {
                             FailureReason::InternalError,
                             format!("witness service unavailable: {error}"),
                             Duration::ZERO,
-                        );
+                        )
+                        .await;
                     }
                     return;
                 }
@@ -304,7 +320,8 @@ impl ProofService {
                                 FailureReason::ProvingError,
                                 format!("input construction failed: {e}"),
                                 Duration::ZERO,
-                            );
+                            )
+                            .await;
                         }
                         return;
                     }
@@ -316,7 +333,8 @@ impl ProofService {
                         proof_type,
                         input.clone(),
                         request.span.clone(),
-                    );
+                    )
+                    .await;
                 }
             }
             ProofServiceMessage::WitnessTimeout { block_hash } => {
@@ -333,7 +351,8 @@ impl ProofService {
                         FailureReason::WitnessTimeout,
                         format!("witness timeout for block {block_hash}"),
                         Duration::ZERO,
-                    );
+                    )
+                    .await;
                 }
             }
             ProofServiceMessage::WitnessIncompatible { block_hash, error } => {
@@ -350,13 +369,14 @@ impl ProofService {
                         FailureReason::ProvingError,
                         format!("witness incompatible: {error}"),
                         Duration::ZERO,
-                    );
+                    )
+                    .await;
                 }
             }
         }
     }
 
-    fn send_worker_input(
+    async fn send_worker_input(
         &mut self,
         worker_input_txs: &HashMap<ProofType, mpsc::Sender<WorkerInput>>,
         proof_type: ProofType,
@@ -374,7 +394,8 @@ impl ProofService {
                 FailureReason::InternalError,
                 format!("no zkVM worker for proof type '{proof_type}'"),
                 Duration::ZERO,
-            );
+            )
+            .await;
             return;
         };
 
@@ -397,12 +418,13 @@ impl ProofService {
                     FailureReason::InternalError,
                     format!("worker input send failed: {reason}"),
                     Duration::ZERO,
-                );
+                )
+                .await;
             }
         }
     }
 
-    fn fail_request(
+    async fn fail_request(
         &mut self,
         new_payload_request_root: Hash256,
         proof_type: ProofType,
@@ -412,15 +434,19 @@ impl ProofService {
     ) {
         self.requested
             .remove(&(new_payload_request_root, proof_type));
-        let _ = self.proof_event_tx.send(
-            ProofFailure {
-                new_payload_request_root,
-                proof_type,
-                reason,
-                error,
-            }
-            .into(),
-        );
+        let failure = ProofFailure {
+            new_payload_request_root,
+            proof_type,
+            reason,
+            error,
+        };
+        // Cache the terminal failure so subscribers that missed the live broadcast get it
+        // replayed on subscribe, exactly like completed proofs.
+        self.failure_cache
+            .write()
+            .await
+            .put((new_payload_request_root, proof_type), failure.clone());
+        let _ = self.proof_event_tx.send(failure.into());
         record_prove(
             proof_type,
             match reason {
@@ -429,6 +455,144 @@ impl ProofService {
             },
             duration,
             0,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use super::*;
+
+    /// Channels whose receivers must outlive the service under test.
+    struct TestChannels {
+        proof_event_rx: broadcast::Receiver<ProofEvent>,
+        _witness_service_rx: mpsc::Receiver<WitnessServiceMessage>,
+        _dashboard_service_rx: mpsc::Receiver<DashboardMessage>,
+    }
+
+    fn test_service(failure_capacity: usize) -> (ProofService, TestChannels) {
+        let proof_cache = Arc::new(RwLock::new(LruCache::new(NonZeroUsize::new(8).unwrap())));
+        let failure_cache = Arc::new(RwLock::new(LruCache::new(
+            NonZeroUsize::new(failure_capacity).unwrap(),
+        )));
+        let (proof_event_tx, proof_event_rx) = broadcast::channel(16);
+        let (witness_service_tx, _witness_service_rx) = mpsc::channel(4);
+        let (dashboard_service_tx, _dashboard_service_rx) = mpsc::channel(4);
+        let service = ProofService::new(
+            proof_cache,
+            failure_cache,
+            proof_event_tx,
+            witness_service_tx,
+            dashboard_service_tx,
+        );
+        (
+            service,
+            TestChannels {
+                proof_event_rx,
+                _witness_service_rx,
+                _dashboard_service_rx,
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn test_failure_cache_respects_lru_bound() {
+        // Arrange
+        let (mut service, _channels) = test_service(2);
+
+        // Act
+        for byte in [1u8, 2, 3] {
+            service
+                .fail_request(
+                    Hash256::repeat_byte(byte),
+                    ProofType::RethZisk,
+                    FailureReason::ProvingError,
+                    "boom".to_owned(),
+                    Duration::ZERO,
+                )
+                .await;
+        }
+
+        // Assert: capacity is 2, so the oldest failure was evicted.
+        let cache = service.failure_cache.read().await;
+        assert_eq!(cache.len(), 2);
+        assert!(!cache.contains(&(Hash256::repeat_byte(1), ProofType::RethZisk)));
+        assert!(cache.contains(&(Hash256::repeat_byte(2), ProofType::RethZisk)));
+        assert!(cache.contains(&(Hash256::repeat_byte(3), ProofType::RethZisk)));
+    }
+
+    #[tokio::test]
+    async fn test_fail_request_caches_and_broadcasts_same_failure() {
+        // Arrange
+        let (mut service, mut channels) = test_service(4);
+        let root = Hash256::repeat_byte(7);
+
+        // Act
+        service
+            .fail_request(
+                root,
+                ProofType::RethZisk,
+                FailureReason::WitnessTimeout,
+                "witness timeout".to_owned(),
+                Duration::ZERO,
+            )
+            .await;
+
+        // Assert: the broadcast event and the cached failure are identical.
+        let broadcast_event = channels.proof_event_rx.try_recv().unwrap();
+        let cached = service
+            .failure_cache
+            .read()
+            .await
+            .peek(&(root, ProofType::RethZisk))
+            .cloned()
+            .expect("failure should be cached");
+        assert_eq!(broadcast_event, ProofEvent::ProofFailure(cached));
+    }
+
+    #[tokio::test]
+    async fn test_completed_proof_evicts_stale_cached_failure() {
+        // Arrange: a cached failure for a request that later succeeds on retry.
+        let (mut service, _channels) = test_service(4);
+        let root = Hash256::repeat_byte(9);
+        service
+            .fail_request(
+                root,
+                ProofType::RethZisk,
+                FailureReason::ProvingError,
+                "boom".to_owned(),
+                Duration::ZERO,
+            )
+            .await;
+
+        // Act
+        service
+            .handle_worker_output(WorkerOutput {
+                new_payload_request_root: root,
+                block_hash: Hash256::repeat_byte(1),
+                block_number: 1,
+                proof_type: ProofType::RethZisk,
+                proof_result: ProofResult::Ok(Bytes::from_static(b"proof bytes")),
+                duration: Duration::ZERO,
+            })
+            .await;
+
+        // Assert: only the completion remains; the stale failure is gone.
+        assert!(
+            !service
+                .failure_cache
+                .read()
+                .await
+                .contains(&(root, ProofType::RethZisk))
+        );
+        assert!(
+            service
+                .proof_cache
+                .read()
+                .await
+                .contains(&(root, ProofType::RethZisk))
         );
     }
 }

--- a/crates/server/src/proof.rs
+++ b/crates/server/src/proof.rs
@@ -246,6 +246,16 @@ impl ProofService {
                     return;
                 }
 
+                // These proof types have been admitted as a new attempt. Their previous
+                // terminal failures are no longer the current state and must not be replayed
+                // to subscribers while the retry is in flight.
+                {
+                    let mut failure_cache = self.failure_cache.write().await;
+                    for &proof_type in &proof_types {
+                        failure_cache.pop(&(new_payload_request_root, proof_type));
+                    }
+                }
+
                 info!(
                     %new_payload_request_root,
                     %block_hash,
@@ -463,6 +473,8 @@ impl ProofService {
 mod tests {
     use std::num::NonZeroUsize;
 
+    use zkboost_types::{HashTreeRoot, Sha2Hasher, SszDecode};
+
     use super::*;
 
     /// Channels whose receivers must outlive the service under test.
@@ -550,6 +562,62 @@ mod tests {
             .cloned()
             .expect("failure should be cached");
         assert_eq!(broadcast_event, ProofEvent::ProofFailure(cached));
+    }
+
+    #[tokio::test]
+    async fn test_retry_admission_evicts_stale_cached_failure() {
+        const NEW_PAYLOAD_REQUEST: &[u8] =
+            include_bytes!("../tests/fixture/new_payload_request.ssz");
+        const CHAIN_CONFIG: &[u8] = include_bytes!("../tests/fixture/chain_config.ssz");
+
+        // Arrange: a prior attempt failed and left a replayable terminal failure.
+        let (mut service, _channels) = test_service(4);
+        let new_payload_request = Arc::new(
+            NewPayloadRequest::from_ssz_bytes(NEW_PAYLOAD_REQUEST)
+                .expect("valid new payload request fixture"),
+        );
+        let new_payload_request_root =
+            Hash256::from(new_payload_request.hash_tree_root(&Sha2Hasher));
+        let chain_config =
+            ChainConfig::from_ssz_bytes(CHAIN_CONFIG).expect("valid chain config fixture");
+        service
+            .fail_request(
+                new_payload_request_root,
+                ProofType::RethZisk,
+                FailureReason::WitnessTimeout,
+                "witness timeout".to_owned(),
+                Duration::ZERO,
+            )
+            .await;
+
+        // Act: resubmitting the same root and proof type is admitted as a new attempt.
+        service
+            .handle_message(
+                ProofServiceMessage::RequestProof {
+                    new_payload_request_root,
+                    new_payload_request,
+                    chain_config,
+                    proof_types: HashSet::from([ProofType::RethZisk]),
+                    span: Span::none(),
+                },
+                &HashMap::new(),
+            )
+            .await;
+
+        // Assert: the retry remains in flight and the prior terminal failure is no longer
+        // replayable. A new failure or completion will establish the next terminal result.
+        assert!(
+            service
+                .requested
+                .contains(&(new_payload_request_root, ProofType::RethZisk))
+        );
+        assert!(
+            !service
+                .failure_cache
+                .read()
+                .await
+                .contains(&(new_payload_request_root, ProofType::RethZisk))
+        );
     }
 
     #[tokio::test]

--- a/crates/server/src/proof/worker.rs
+++ b/crates/server/src/proof/worker.rs
@@ -83,13 +83,15 @@ pub(crate) async fn run_worker(
             otel.name = otel_name,
             otel.status_code = tracing::field::Empty,
             error_reason = tracing::field::Empty,
+            // Recorded by the cluster backend once the cluster assigns a job id.
+            job_id = tracing::field::Empty,
         );
 
         let _ =
             dashboard_service_tx.try_send(DashboardMessage::prove_start(block_hash, proof_type));
 
         let start = Instant::now();
-        let proof_result = match timeout(proof_timeout, zkvm.prove(&input.stateless_input))
+        let proof_result = match timeout(proof_timeout, zkvm.prove(&input.stateless_input, &span))
             .instrument(span.clone())
             .await
         {

--- a/crates/server/src/proof/zkvm.rs
+++ b/crates/server/src/proof/zkvm.rs
@@ -148,11 +148,18 @@ impl zkVMInstance {
 
     /// Generates a compressed proof for the given payload, returning raw proof bytes.
     ///
+    /// `prove_span` is the worker's prove span; backends that learn a backend-side job
+    /// identifier (currently the cluster) record it there explicitly.
+    ///
     /// The attempt is unbounded here. The per-zkVM worker wraps this call in
     /// [`tokio::time::timeout`] using [`proof_timeout`](Self::proof_timeout), so a
     /// timeout drops this future. For the cluster backend the in-flight job is
     /// then cancelled server-side when its `ClusterProveJob` guard is dropped.
-    pub(crate) async fn prove(&self, stateless_input: &StatelessInput) -> anyhow::Result<Vec<u8>> {
+    pub(crate) async fn prove(
+        &self,
+        stateless_input: &StatelessInput,
+        prove_span: &tracing::Span,
+    ) -> anyhow::Result<Vec<u8>> {
         if let Self::Mock { vm, .. } = self {
             return vm.prove(stateless_input).await;
         }
@@ -166,7 +173,13 @@ impl zkVMInstance {
                 let (_, proof, _) = client.prove(input).await?;
                 Ok(proof.0)
             }
-            Self::Cluster { client, .. } => client.create_prove_job(&input).await?.wait().await,
+            Self::Cluster { client, .. } => {
+                client
+                    .create_prove_job(&input, prove_span)
+                    .await?
+                    .wait()
+                    .await
+            }
             Self::Mock { .. } | Self::Verifier { .. } => unreachable!(),
         }
     }

--- a/crates/server/src/proof/zkvm/cluster_client.rs
+++ b/crates/server/src/proof/zkvm/cluster_client.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use ere_cluster_client_zisk::{Error as ZiskError, Input, RemoteProverConfig, ZiskClusterClient};
 use ere_verifier::zkVMKind;
 use ere_verifier_zisk::codec::Encode;
-use tracing::warn;
+use tracing::{Span, info, warn};
 use zkboost_types::ProofType;
 
 /// A client for an external proving cluster, with one variant per supported zkVM.
@@ -49,7 +49,14 @@ impl ClusterClient {
 
     /// Submits a prove job for `input`, returning a [`ClusterProveJob`] that
     /// drives it to completion.
-    pub(crate) async fn create_prove_job(&self, input: &Input) -> anyhow::Result<ClusterProveJob> {
+    ///
+    /// `prove_span` is the worker's prove span, which declares an empty `job_id` field;
+    /// the id the cluster assigns is recorded there.
+    pub(crate) async fn create_prove_job(
+        &self,
+        input: &Input,
+        prove_span: &Span,
+    ) -> anyhow::Result<ClusterProveJob> {
         match self {
             Self::Zisk(client) => {
                 let job_id = match client.create_prove_job(input).await {
@@ -64,6 +71,10 @@ impl ClusterClient {
                     }
                     Err(err) => return Err(err).context("submit zisk prove job"),
                 };
+                // Recorded on the explicitly passed span rather than `Span::current()`, so the
+                // id cannot silently land elsewhere if an intermediate span is ever introduced.
+                prove_span.record("job_id", job_id.as_str());
+                info!(%job_id, "zisk cluster prove job created");
                 Ok(ClusterProveJob::Zisk {
                     client: client.clone(),
                     job_id: Some(job_id),

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -111,6 +111,12 @@ impl zkBoostServer {
             NonZeroUsize::new(self.config.proof_cache_size * self.zkvms.len())
                 .expect("proof_cache_size must be non-zero"),
         )));
+        // Terminal failures are cached with the same bound as completed proofs, so late SSE
+        // subscribers can have missed failure events replayed.
+        let failure_cache = Arc::new(RwLock::new(LruCache::new(
+            NonZeroUsize::new(self.config.proof_cache_size * self.zkvms.len())
+                .expect("proof_cache_size must be non-zero"),
+        )));
 
         let (proof_service_tx, proof_service_rx) = mpsc::channel(CHANNEL_CAPACITY);
         let (witness_service_tx, witness_service_rx) = mpsc::channel(CHANNEL_CAPACITY);
@@ -152,6 +158,7 @@ impl zkBoostServer {
 
         let proof_service = ProofService::new(
             proof_cache.clone(),
+            failure_cache.clone(),
             proof_event_tx,
             witness_service_tx,
             dashboard_service_tx.clone(),
@@ -189,6 +196,7 @@ impl zkBoostServer {
             self.blob_params,
             self.zkvms.clone(),
             proof_cache,
+            failure_cache,
             self.metrics,
             dashboard,
             proof_service_tx,

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -54,7 +54,10 @@ impl zkBoostServer {
     /// from the given configuration.
     pub async fn new(config: Config, metrics: PrometheusHandle) -> anyhow::Result<Self> {
         info!(url = %config.el_endpoint, "el endpoint configured");
-        let el_client = Arc::new(ElClient::new(config.el_endpoint.clone()));
+        let el_client = Arc::new(ElClient::new(
+            config.el_endpoint.clone(),
+            config.el_header_map()?,
+        )?);
 
         let blob_params = load_blob_params(&config.chain_config_path, &el_client).await?;
         info!(

--- a/crates/server/tests/fixture/chain_config.json
+++ b/crates/server/tests/fixture/chain_config.json
@@ -1,0 +1,45 @@
+{
+  "chainId": 3151908,
+  "homesteadBlock": 0,
+  "daoForkSupport": false,
+  "eip150Block": 0,
+  "eip155Block": 0,
+  "eip158Block": 0,
+  "byzantiumBlock": 0,
+  "constantinopleBlock": 0,
+  "petersburgBlock": 0,
+  "istanbulBlock": 0,
+  "berlinBlock": 0,
+  "londonBlock": 0,
+  "mergeNetsplitBlock": 0,
+  "shanghaiTime": 0,
+  "cancunTime": 0,
+  "pragueTime": 0,
+  "osakaTime": 0,
+  "bpo1Time": 0,
+  "terminalTotalDifficulty": 0,
+  "terminalTotalDifficultyPassed": true,
+  "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
+  "blobSchedule": {
+    "bpo1": {
+      "baseFeeUpdateFraction": 8346193,
+      "max": 15,
+      "target": 10
+    },
+    "cancun": {
+      "baseFeeUpdateFraction": 3338477,
+      "max": 6,
+      "target": 3
+    },
+    "osaka": {
+      "baseFeeUpdateFraction": 5007716,
+      "max": 9,
+      "target": 6
+    },
+    "prague": {
+      "baseFeeUpdateFraction": 5007716,
+      "max": 9,
+      "target": 6
+    }
+  }
+}

--- a/crates/server/tests/integration.rs
+++ b/crates/server/tests/integration.rs
@@ -342,6 +342,11 @@ async fn test_proof_failure() {
         .assert_proof_failure(FailureReason::ProvingError)
         .await;
     harness.assert_get_proof_not_found().await;
+
+    // Subscribing again after the failure receives it replayed from the failure cache.
+    harness
+        .assert_proof_failure(FailureReason::ProvingError)
+        .await;
 }
 
 #[tokio::test]
@@ -372,4 +377,9 @@ async fn test_proof_timeout() {
         .assert_proof_failure(FailureReason::ProvingTimeout)
         .await;
     harness.assert_get_proof_not_found().await;
+
+    // Subscribing again after the failure receives it replayed from the failure cache.
+    harness
+        .assert_proof_failure(FailureReason::ProvingTimeout)
+        .await;
 }

--- a/crates/server/tests/integration.rs
+++ b/crates/server/tests/integration.rs
@@ -143,6 +143,7 @@ async fn start_zkboost_server(
     let config = Config {
         port: 0,
         el_endpoint,
+        el_headers: HashMap::new(),
         chain_config_path: None,
         witness_timeout_secs,
         proof_cache_size: 128,

--- a/crates/server/tests/otel_request_span.rs
+++ b/crates/server/tests/otel_request_span.rs
@@ -1,0 +1,111 @@
+//! Verifies that the server's `request` span joins a caller-supplied W3C trace context
+//! (`traceparent`) and carries the expected OpenTelemetry span kind and HTTP attributes.
+//!
+//! This lives in its own integration-test binary on purpose: it installs a process-global
+//! tracing subscriber so spans created on the server's tasks are observed. Sharing a process
+//! with other tests would both race on the global subscriber and poison the global callsite
+//! interest cache, which previously required warm-up/retry workarounds.
+
+use std::{collections::HashMap, time::Duration};
+
+use metrics_exporter_prometheus::PrometheusBuilder;
+use opentelemetry::trace::{SpanKind, TracerProvider};
+use opentelemetry_sdk::{
+    propagation::TraceContextPropagator,
+    trace::{InMemorySpanExporter, SdkTracerProvider},
+};
+use tracing_subscriber::layer::SubscriberExt;
+use zkboost_server::{
+    config::{Config, DashboardConfig, MockProvingTime, zkVMConfig},
+    server::zkBoostServer,
+};
+use zkboost_types::ProofType;
+
+/// Sends a request carrying a W3C `traceparent` header and asserts the exported `request`
+/// span joins the caller's trace: same trace id, parented under the caller's span id.
+#[tokio::test]
+async fn test_request_span_joins_remote_trace_context() {
+    const TRACE_ID: &str = "0af7651916cd43dd8448eb211c80319c";
+    const PARENT_SPAN_ID: &str = "b7ad6b7169203331";
+
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_opentelemetry::OpenTelemetryLayer::new(provider.tracer("test")),
+    );
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("no other subscriber should be installed in this test binary");
+
+    // A local chain config file lets the server start without contacting the EL endpoint.
+    let config = Config {
+        port: 0,
+        el_endpoint: "http://127.0.0.1:1/".parse().unwrap(),
+        el_headers: HashMap::new(),
+        chain_config_path: Some(
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fixture/chain_config.json"
+            )
+            .into(),
+        ),
+        witness_timeout_secs: 12,
+        proof_cache_size: 128,
+        witness_cache_size: 128,
+        dashboard: DashboardConfig::default(),
+        zkvm: vec![zkVMConfig::Mock {
+            proof_type: ProofType::RethZisk,
+            proof_timeout_secs: 12,
+            mock_proving_time: MockProvingTime::Constant { ms: 10 },
+            mock_proof_size: 64,
+            mock_failure: false,
+        }],
+    };
+    let metrics = PrometheusBuilder::new().build_recorder().handle();
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let server = zkBoostServer::new(config, metrics).await.unwrap();
+    let (addr, _handles) = server.run(shutdown.clone()).await.unwrap();
+
+    let response = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{}/v1/proof_types", addr.port()))
+        .header("traceparent", format!("00-{TRACE_ID}-{PARENT_SPAN_ID}-01"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    // The request span stays open until the response body is fully sent.
+    response.text().await.unwrap();
+
+    // The server closes the span shortly after the client finishes reading the body; poll
+    // briefly for the exported span rather than racing that completion.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let request_span = loop {
+        provider.force_flush().unwrap();
+        let spans = exporter.get_finished_spans().unwrap();
+        if let Some(span) = spans.iter().find(|span| span.name == "request") {
+            break span.clone();
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "request span should be exported"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    assert_eq!(request_span.span_context.trace_id().to_string(), TRACE_ID);
+    assert_eq!(request_span.parent_span_id.to_string(), PARENT_SPAN_ID);
+    assert_eq!(request_span.span_kind, SpanKind::Server);
+    let attribute = |key: &str| {
+        request_span
+            .attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == key)
+            .map(|kv| kv.value.as_str().into_owned())
+    };
+    assert_eq!(attribute("http.request.method").as_deref(), Some("GET"));
+    assert_eq!(attribute("url.path").as_deref(), Some("/v1/proof_types"));
+
+    shutdown.cancel();
+}

--- a/docker/example/mock-zkattestor/zkboost/config.toml
+++ b/docker/example/mock-zkattestor/zkboost/config.toml
@@ -1,6 +1,10 @@
 port = 3000
 el_endpoint = "http://host.docker.internal:32003"
 
+# Optional HTTP headers applied to every EL JSON-RPC request.
+# [el_headers]
+# Authorization = "Bearer <token>"
+
 [dashboard]
 enabled = true
 

--- a/docker/example/observability/zkboost/config.toml
+++ b/docker/example/observability/zkboost/config.toml
@@ -1,6 +1,10 @@
 port = 3000
 el_endpoint = "http://host.docker.internal:32003"
 
+# Optional HTTP headers applied to every EL JSON-RPC request.
+# [el_headers]
+# Authorization = "Bearer <token>"
+
 [dashboard]
 enabled = true
 


### PR DESCRIPTION
## Summary

- Add W3C trace-context extraction on server requests and optional propagation from zkboost-client.
- Enrich request/proving spans with HTTP attributes, span kind, and Zisk cluster `job_id`.
- Support configurable EL HTTP headers, including validation, sensitive-value handling, and redacted logging.
- Cache terminal proof failures and replay them to late SSE subscribers, mirroring successful-proof replay.

Failure replay uses a bounded, process-local LRU with latest-wins semantics. A later success evicts a stale failure.

## Validation

- Workspace tests and strict clippy pass.
- Verified authenticated EL requests using custom headers.
- Verified end-to-end trace propagation between proofessoor and zkBoost.
- Verified failure replay across a proofessoor disconnect and reconciliation.
