### PR TITLE
feat(server,types): stage-timing observability — queue-wait metric, self-describing completions, identified spans

### DIFF
--- a/crates/server/src/http/v1/get_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/get_execution_proof_requests.rs
@@ -134,6 +134,9 @@ mod tests {
             proof_type: ProofType::RethZisk,
             reason: FailureReason::ProvingError,
             error: "proving exploded".to_owned(),
+            witness_ms: None,
+            queue_wait_ms: None,
+            prove_ms: None,
         };
         state
             .failure_cache

--- a/crates/server/src/http/v1/get_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/get_execution_proof_requests.rs
@@ -44,6 +44,11 @@ pub(crate) async fn get_execution_proof_requests(
                             ProofComplete {
                                 new_payload_request_root: *new_payload_request_root,
                                 proof_type: *proof_type,
+                                // Replayed from the proof cache, which stores only the
+                                // proof bytes — the stage timings are no longer known.
+                                witness_ms: None,
+                                queue_wait_ms: None,
+                                prove_ms: None,
                             }
                             .into()
                         })

--- a/crates/server/src/http/v1/post_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/post_execution_proof_requests.rs
@@ -69,7 +69,13 @@ pub(crate) async fn post_execution_proof_requests(
     let timestamp = new_payload_request.timestamp();
     let gas_used = new_payload_request.gas_used();
 
-    let span = info_span!("request_proof", block_number, timestamp, gas_used);
+    let span = info_span!(
+        "request_proof",
+        new_payload_request_root = %new_payload_request_root,
+        block_number,
+        timestamp,
+        gas_used
+    );
 
     state
         .proof_service_tx

--- a/crates/server/src/metrics.rs
+++ b/crates/server/src/metrics.rs
@@ -20,6 +20,7 @@ const HTTP_REQUESTS_IN_FLIGHT: &str = "zkboost_http_requests_in_flight";
 const WITNESS_FETCH_DURATION_SECONDS: &str = "zkboost_witness_fetch_duration_seconds";
 const WITNESS_BYTES: &str = "zkboost_witness_bytes";
 const WITNESS_FETCH_TOTAL: &str = "zkboost_witness_fetch_total";
+const QUEUE_WAIT_DURATION_SECONDS: &str = "zkboost_queue_wait_duration_seconds";
 const PROVE_TOTAL: &str = "zkboost_prove_total";
 const PROVE_DURATION_SECONDS: &str = "zkboost_prove_duration_seconds";
 const PROVE_PROOF_BYTES: &str = "zkboost_prove_proof_bytes";
@@ -32,6 +33,13 @@ const DEFAULT_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 ];
 
+// Queue wait is unbounded (nothing caps how long an input sits in the worker
+// channel), so unlike the prove buckets these keep a long tail: backlogs of
+// minutes are exactly what this metric exists to expose.
+const QUEUE_WAIT_BUCKETS: &[f64] = &[
+    0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0, 60.0, 120.0, 300.0, 900.0,
+];
+
 /// Initialize the Prometheus metrics exporter and register metric descriptions.
 ///
 /// Returns a handle that can be used to render metrics for the `/metrics` endpoint.
@@ -42,6 +50,20 @@ pub fn init_metrics() -> PrometheusHandle {
         .set_buckets_for_metric(
             Matcher::Full(PROVE_DURATION_SECONDS.to_owned()),
             &from_fn::<_, 24, _>(|i| (i + 1) as f64 * 0.5),
+        )
+        .unwrap()
+        // Witness fetches run under the slot-aligned witness timeout, so give
+        // them the same 0.5s-step resolution up to 12.0 as the prove buckets —
+        // the default buckets end at 10.0 and hide successful 10-12s fetches
+        // in +Inf.
+        .set_buckets_for_metric(
+            Matcher::Full(WITNESS_FETCH_DURATION_SECONDS.to_owned()),
+            &from_fn::<_, 24, _>(|i| (i + 1) as f64 * 0.5),
+        )
+        .unwrap()
+        .set_buckets_for_metric(
+            Matcher::Full(QUEUE_WAIT_DURATION_SECONDS.to_owned()),
+            QUEUE_WAIT_BUCKETS,
         )
         .unwrap()
         .install_recorder()
@@ -58,6 +80,10 @@ pub fn init_metrics() -> PrometheusHandle {
     describe_histogram!(WITNESS_BYTES, "witness size");
 
     // Prove operation metrics
+    describe_histogram!(
+        QUEUE_WAIT_DURATION_SECONDS,
+        "time a proof request waits in the worker channel between dispatch and dequeue"
+    );
     describe_counter!(PROVE_TOTAL, "total prove operations");
     describe_histogram!(PROVE_DURATION_SECONDS, "proof generation duration");
     describe_histogram!(PROVE_PROOF_BYTES, "proof size");
@@ -109,6 +135,18 @@ pub fn record_witness_fetch(status: &'static str, duration: Duration, witness_si
         histogram!(WITNESS_FETCH_DURATION_SECONDS).record(duration.as_secs_f64());
         histogram!(WITNESS_BYTES).record(witness_size as f64);
     }
+}
+
+/// Record how long a proof request waited in the worker channel before a
+/// worker dequeued it. This is the only place queue wait is observable: the
+/// prove duration histogram starts after dequeue, so without this metric a
+/// backlog is invisible.
+pub fn record_queue_wait(proof_type: ProofType, duration: Duration) {
+    histogram!(
+        QUEUE_WAIT_DURATION_SECONDS,
+        "proof_type" => proof_type.to_string(),
+    )
+    .record(duration.as_secs_f64());
 }
 
 /// Record a prove operation result.

--- a/crates/server/src/proof.rs
+++ b/crates/server/src/proof.rs
@@ -59,6 +59,10 @@ struct PendingRequest {
     chain_config: ChainConfig,
     proof_types: HashSet<ProofType>,
     span: Span,
+    /// When the first request for this block was admitted; measures witness
+    /// wait. Kept across `and_modify` so later proof types added to the same
+    /// pending block inherit the original admission time.
+    requested_at: Instant,
 }
 
 /// Bounded cache of terminal proof failures, replayed to SSE subscribers that subscribe after
@@ -131,6 +135,8 @@ impl ProofService {
             proof_type,
             proof_result,
             duration,
+            witness_wait,
+            queue_wait,
         } = output;
 
         trace!(%block_hash, block_number, "received WorkerOutput");
@@ -158,6 +164,9 @@ impl ProofService {
                     ProofComplete {
                         new_payload_request_root,
                         proof_type,
+                        witness_ms: Some(witness_wait.as_millis() as u64),
+                        queue_wait_ms: Some(queue_wait.as_millis() as u64),
+                        prove_ms: Some(duration.as_millis() as u64),
                     }
                     .into(),
                 );
@@ -301,6 +310,7 @@ impl ProofService {
                         chain_config,
                         proof_types,
                         span,
+                        requested_at: Instant::now(),
                     });
 
                 let _ = self.dashboard_service_tx.try_send(dashboard_msg);
@@ -314,6 +324,7 @@ impl ProofService {
                 let Some(request) = self.pending.remove(&block_hash) else {
                     return;
                 };
+                let witness_wait = request.requested_at.elapsed();
 
                 let input = match StatelessInput::new(
                     &request.new_payload_request,
@@ -343,6 +354,7 @@ impl ProofService {
                         proof_type,
                         input.clone(),
                         request.span.clone(),
+                        witness_wait,
                     )
                     .await;
                 }
@@ -392,6 +404,7 @@ impl ProofService {
         proof_type: ProofType,
         stateless_input: Arc<StatelessInput>,
         span: Span,
+        witness_wait: Duration,
     ) {
         let new_payload_request_root = stateless_input.root();
         let block_hash = stateless_input.block_hash();
@@ -413,6 +426,7 @@ impl ProofService {
             stateless_input,
             span,
             queued_at: Instant::now(),
+            witness_wait,
         };
         match tx.try_send(worker_input) {
             Ok(()) => {
@@ -645,6 +659,8 @@ mod tests {
                 proof_type: ProofType::RethZisk,
                 proof_result: ProofResult::Ok(Bytes::from_static(b"proof bytes")),
                 duration: Duration::ZERO,
+                witness_wait: Duration::ZERO,
+                queue_wait: Duration::ZERO,
             })
             .await;
 

--- a/crates/server/src/proof.rs
+++ b/crates/server/src/proof.rs
@@ -53,6 +53,16 @@ pub(crate) enum ProofServiceMessage {
     WitnessIncompatible { block_hash: Hash256, error: String },
 }
 
+/// Stage timings known at the point a request fails; `None` means the stage
+/// never ran for this request (or its timing is unknown), which locates how
+/// far the request got before dying.
+#[derive(Debug, Clone, Copy, Default)]
+struct StageTimings {
+    witness: Option<Duration>,
+    queue_wait: Option<Duration>,
+    prove: Option<Duration>,
+}
+
 struct PendingRequest {
     new_payload_request: Arc<NewPayloadRequest>,
     new_payload_request_root: Hash256,
@@ -180,6 +190,11 @@ impl ProofService {
                     FailureReason::ProvingError,
                     error,
                     duration,
+                    StageTimings {
+                        witness: Some(witness_wait),
+                        queue_wait: Some(queue_wait),
+                        prove: Some(duration),
+                    },
                 )
                 .await;
             }
@@ -194,6 +209,11 @@ impl ProofService {
                         duration.as_secs_f64()
                     ),
                     duration,
+                    StageTimings {
+                        witness: Some(witness_wait),
+                        queue_wait: Some(queue_wait),
+                        prove: Some(duration),
+                    },
                 )
                 .await;
             }
@@ -293,6 +313,7 @@ impl ProofService {
                             FailureReason::InternalError,
                             format!("witness service unavailable: {error}"),
                             Duration::ZERO,
+                            StageTimings::default(),
                         )
                         .await;
                     }
@@ -341,6 +362,10 @@ impl ProofService {
                                 FailureReason::ProvingError,
                                 format!("input construction failed: {e}"),
                                 Duration::ZERO,
+                                StageTimings {
+                                    witness: Some(witness_wait),
+                                    ..Default::default()
+                                },
                             )
                             .await;
                         }
@@ -365,6 +390,7 @@ impl ProofService {
                 let Some(request) = self.pending.remove(&block_hash) else {
                     return;
                 };
+                let witness_wait = request.requested_at.elapsed();
                 for &proof_type in &request.proof_types {
                     warn!(%block_hash, %proof_type, "pending request witness timed out");
                     self.fail_request(
@@ -373,6 +399,10 @@ impl ProofService {
                         FailureReason::WitnessTimeout,
                         format!("witness timeout for block {block_hash}"),
                         Duration::ZERO,
+                        StageTimings {
+                            witness: Some(witness_wait),
+                            ..Default::default()
+                        },
                     )
                     .await;
                 }
@@ -383,6 +413,7 @@ impl ProofService {
                 let Some(request) = self.pending.remove(&block_hash) else {
                     return;
                 };
+                let witness_wait = request.requested_at.elapsed();
                 for &proof_type in &request.proof_types {
                     warn!(%block_hash, %proof_type, %error, "pending request witness incompatible");
                     self.fail_request(
@@ -391,6 +422,10 @@ impl ProofService {
                         FailureReason::ProvingError,
                         format!("witness incompatible: {error}"),
                         Duration::ZERO,
+                        StageTimings {
+                            witness: Some(witness_wait),
+                            ..Default::default()
+                        },
                     )
                     .await;
                 }
@@ -417,6 +452,10 @@ impl ProofService {
                 FailureReason::InternalError,
                 format!("no zkVM worker for proof type '{proof_type}'"),
                 Duration::ZERO,
+                StageTimings {
+                    witness: Some(witness_wait),
+                    ..Default::default()
+                },
             )
             .await;
             return;
@@ -443,6 +482,10 @@ impl ProofService {
                     FailureReason::InternalError,
                     format!("worker input send failed: {reason}"),
                     Duration::ZERO,
+                    StageTimings {
+                        witness: Some(witness_wait),
+                        ..Default::default()
+                    },
                 )
                 .await;
             }
@@ -456,6 +499,7 @@ impl ProofService {
         reason: FailureReason,
         error: String,
         duration: Duration,
+        timings: StageTimings,
     ) {
         self.requested
             .remove(&(new_payload_request_root, proof_type));
@@ -464,6 +508,9 @@ impl ProofService {
             proof_type,
             reason,
             error,
+            witness_ms: timings.witness.map(|d| d.as_millis() as u64),
+            queue_wait_ms: timings.queue_wait.map(|d| d.as_millis() as u64),
+            prove_ms: timings.prove.map(|d| d.as_millis() as u64),
         };
         // Cache the terminal failure so subscribers that missed the live broadcast get it
         // replayed on subscribe, exactly like completed proofs.
@@ -538,6 +585,7 @@ mod tests {
                     FailureReason::ProvingError,
                     "boom".to_owned(),
                     Duration::ZERO,
+                    StageTimings::default(),
                 )
                 .await;
         }
@@ -564,6 +612,7 @@ mod tests {
                 FailureReason::WitnessTimeout,
                 "witness timeout".to_owned(),
                 Duration::ZERO,
+                StageTimings::default(),
             )
             .await;
 
@@ -602,6 +651,7 @@ mod tests {
                 FailureReason::WitnessTimeout,
                 "witness timeout".to_owned(),
                 Duration::ZERO,
+                StageTimings::default(),
             )
             .await;
 
@@ -647,6 +697,7 @@ mod tests {
                 FailureReason::ProvingError,
                 "boom".to_owned(),
                 Duration::ZERO,
+                StageTimings::default(),
             )
             .await;
 

--- a/crates/server/src/proof.rs
+++ b/crates/server/src/proof.rs
@@ -8,7 +8,7 @@ pub mod zkvm;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use bytes::Bytes;
@@ -412,6 +412,7 @@ impl ProofService {
         let worker_input = WorkerInput {
             stateless_input,
             span,
+            queued_at: Instant::now(),
         };
         match tx.try_send(worker_input) {
             Ok(()) => {

--- a/crates/server/src/proof/worker.rs
+++ b/crates/server/src/proof/worker.rs
@@ -14,6 +14,7 @@ use zkboost_types::{Hash256, ProofType};
 
 use crate::{
     dashboard::DashboardMessage,
+    metrics,
     proof::{input::StatelessInput, zkvm::zkVMInstance},
 };
 
@@ -21,6 +22,9 @@ use crate::{
 pub(crate) struct WorkerInput {
     pub(crate) stateless_input: Arc<StatelessInput>,
     pub(crate) span: Span,
+    /// When the input was dispatched into the worker channel; measures queue
+    /// wait at dequeue.
+    pub(crate) queued_at: Instant,
 }
 
 /// Output returned by a worker after a proof attempt.
@@ -74,6 +78,8 @@ pub(crate) async fn run_worker(
         let new_payload_request_root = input.stateless_input.root();
         let block_hash = input.stateless_input.block_hash();
         let block_number = input.stateless_input.block_number();
+
+        metrics::record_queue_wait(proof_type, input.queued_at.elapsed());
 
         info!(%block_hash, %proof_type, "proving");
 

--- a/crates/server/src/proof/worker.rs
+++ b/crates/server/src/proof/worker.rs
@@ -25,6 +25,9 @@ pub(crate) struct WorkerInput {
     /// When the input was dispatched into the worker channel; measures queue
     /// wait at dequeue.
     pub(crate) queued_at: Instant,
+    /// How long the request waited for its witness before dispatch; carried
+    /// through to the completion event.
+    pub(crate) witness_wait: Duration,
 }
 
 /// Output returned by a worker after a proof attempt.
@@ -36,6 +39,8 @@ pub(crate) struct WorkerOutput {
     pub(crate) proof_type: ProofType,
     pub(crate) proof_result: ProofResult,
     pub(crate) duration: Duration,
+    pub(crate) witness_wait: Duration,
+    pub(crate) queue_wait: Duration,
 }
 
 /// Result of a single proof generation attempt.
@@ -79,7 +84,8 @@ pub(crate) async fn run_worker(
         let block_hash = input.stateless_input.block_hash();
         let block_number = input.stateless_input.block_number();
 
-        metrics::record_queue_wait(proof_type, input.queued_at.elapsed());
+        let queue_wait = input.queued_at.elapsed();
+        metrics::record_queue_wait(proof_type, queue_wait);
 
         info!(%block_hash, %proof_type, "proving");
 
@@ -87,6 +93,7 @@ pub(crate) async fn run_worker(
             parent: &input.span,
             "prove",
             otel.name = otel_name,
+            new_payload_request_root = %new_payload_request_root,
             otel.status_code = tracing::field::Empty,
             error_reason = tracing::field::Empty,
             // Recorded by the cluster backend once the cluster assigns a job id.
@@ -125,6 +132,8 @@ pub(crate) async fn run_worker(
                 proof_type,
                 proof_result,
                 duration,
+                witness_wait: input.witness_wait,
+                queue_wait,
             })
             .await
         {

--- a/crates/server/src/witness.rs
+++ b/crates/server/src/witness.rs
@@ -225,6 +225,10 @@ async fn fetch_witness(
     let span = info_span!(
         parent: &span,
         "fetch_witness",
+        // The witness service is keyed by execution block hash and serves all
+        // requests for that block, so the hash — not a request root — is its
+        // identity.
+        block_hash = %block_hash,
         otel.status_code = tracing::field::Empty,
         error_reason = tracing::field::Empty,
     );

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -231,6 +231,22 @@ pub struct ProofComplete {
     pub new_payload_request_root: Hash256,
     /// Proof type.
     pub proof_type: ProofType,
+    /// Time the request waited for its execution witness, in milliseconds
+    /// (request admission until the witness became available, including fetch
+    /// retries and coalesced waits behind an earlier fetch for the same block).
+    ///
+    /// `None` when the producer predates this field or replays a cached proof
+    /// whose timings are no longer known — absence means "unknown", not zero.
+    #[serde(default)]
+    pub witness_ms: Option<u64>,
+    /// Time the proof job waited in the worker queue between dispatch and
+    /// dequeue, in milliseconds. `None` semantics as for `witness_ms`.
+    #[serde(default)]
+    pub queue_wait_ms: Option<u64>,
+    /// Proof generation time after dequeue, in milliseconds. `None` semantics
+    /// as for `witness_ms`.
+    #[serde(default)]
+    pub prove_ms: Option<u64>,
 }
 
 /// Payload for a failed proof event.
@@ -262,7 +278,52 @@ pub enum FailureReason {
 
 #[cfg(test)]
 mod tests {
-    use crate::{BackendKind, ProofType, ProofTypeInfo, ProofTypesResponse};
+    use crate::{
+        BackendKind, Hash256, ProofComplete, ProofType, ProofTypeInfo, ProofTypesResponse,
+    };
+
+    /// A ProofComplete emitted by a producer that predates the stage-timing
+    /// fields must still deserialize — absent keys read as None, not an error.
+    #[test]
+    fn test_proof_complete_deserializes_without_stage_timings() {
+        let legacy = r#"{
+            "new_payload_request_root": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "proof_type": "reth-zisk"
+        }"#;
+        let event: ProofComplete = serde_json::from_str(legacy).unwrap();
+        assert_eq!(event.witness_ms, None);
+        assert_eq!(event.queue_wait_ms, None);
+        assert_eq!(event.prove_ms, None);
+    }
+
+    /// A consumer built before new fields exist must tolerate them: serde's
+    /// default behavior ignores unknown keys, and nothing here may opt out of
+    /// that (no deny_unknown_fields), or producers could never add fields.
+    #[test]
+    fn test_proof_complete_tolerates_unknown_fields() {
+        let future = r#"{
+            "new_payload_request_root": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "proof_type": "reth-zisk",
+            "some_future_field": 42
+        }"#;
+        let event: ProofComplete = serde_json::from_str(future).unwrap();
+        assert_eq!(event.proof_type, ProofType::RethZisk);
+    }
+
+    /// Populated stage timings survive a serialize/deserialize round trip.
+    #[test]
+    fn test_proof_complete_stage_timings_round_trip() {
+        let event = ProofComplete {
+            new_payload_request_root: Hash256::from([1u8; 32]),
+            proof_type: ProofType::RethZisk,
+            witness_ms: Some(1_500),
+            queue_wait_ms: Some(45_000),
+            prove_ms: Some(8_000),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let back: ProofComplete = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, event);
+    }
 
     #[test]
     fn test_backend_kind_serialization() {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -260,6 +260,22 @@ pub struct ProofFailure {
     pub reason: FailureReason,
     /// Human-readable error message with details about the failure.
     pub error: String,
+    /// Time the request waited for its execution witness, in milliseconds.
+    /// On failures, `None` additionally means the stage never ran for this
+    /// request (e.g. a request rejected at admission), so absence is itself
+    /// diagnostic: it locates how far the request got before dying.
+    #[serde(default)]
+    pub witness_ms: Option<u64>,
+    /// Time the proof job waited in the worker queue, in milliseconds.
+    /// `None` semantics as for `witness_ms` — e.g. always `None` for
+    /// witness-timeout failures, which die before dispatch.
+    #[serde(default)]
+    pub queue_wait_ms: Option<u64>,
+    /// Time spent proving before the failure, in milliseconds (for proving
+    /// timeouts this is the exhausted budget). `None` semantics as for
+    /// `witness_ms`.
+    #[serde(default)]
+    pub prove_ms: Option<u64>,
 }
 
 /// Failure reason of a proof request.
@@ -279,7 +295,8 @@ pub enum FailureReason {
 #[cfg(test)]
 mod tests {
     use crate::{
-        BackendKind, Hash256, ProofComplete, ProofType, ProofTypeInfo, ProofTypesResponse,
+        BackendKind, FailureReason, Hash256, ProofComplete, ProofFailure, ProofType, ProofTypeInfo,
+        ProofTypesResponse,
     };
 
     /// A ProofComplete emitted by a producer that predates the stage-timing
@@ -308,6 +325,41 @@ mod tests {
         }"#;
         let event: ProofComplete = serde_json::from_str(future).unwrap();
         assert_eq!(event.proof_type, ProofType::RethZisk);
+    }
+
+    /// A ProofFailure emitted by a producer that predates the stage-timing
+    /// fields must still deserialize — absent keys read as None.
+    #[test]
+    fn test_proof_failure_deserializes_without_stage_timings() {
+        let legacy = r#"{
+            "new_payload_request_root": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "proof_type": "reth-zisk",
+            "reason": "proving_timeout",
+            "error": "proving timed out"
+        }"#;
+        let event: ProofFailure = serde_json::from_str(legacy).unwrap();
+        assert_eq!(event.witness_ms, None);
+        assert_eq!(event.queue_wait_ms, None);
+        assert_eq!(event.prove_ms, None);
+    }
+
+    /// Partially-populated failure timings survive a round trip — the mixed
+    /// Some/None shape is the normal case for failures (a witness-timeout
+    /// failure has witness_ms but no queue or prove component).
+    #[test]
+    fn test_proof_failure_stage_timings_round_trip() {
+        let event = ProofFailure {
+            new_payload_request_root: Hash256::from([2u8; 32]),
+            proof_type: ProofType::RethZisk,
+            reason: FailureReason::WitnessTimeout,
+            error: "witness timeout".to_owned(),
+            witness_ms: Some(12_000),
+            queue_wait_ms: None,
+            prove_ms: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let back: ProofFailure = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, event);
     }
 
     /// Populated stage timings survive a serialize/deserialize round trip.


### PR DESCRIPTION
## Problem

Per-stage timing of a proof request is only partially observable:

- `zkboost_prove_duration_seconds` starts **after** a worker dequeues the job — time waiting in the worker channel between dispatch and dequeue appears in **no metric**. Under sustained load that wait dominates: we observed traces where `request_proof` spanned 5m16s containing only ~6.6s of witness fetch and ~21s of proving, the rest being invisible queue wait.
- Consumers wanting per-request stage attribution must either poll `/dashboard/state` (bounded retention, lost on restart) or subtract span timestamps in a trace backend — both lossy reconstructions of numbers the server already holds at completion time.
- The stage spans (`request_proof`, `fetch_witness`, `prove/*`) carry no identifying attributes, so span rows in trace UIs can't be related to a block without walking the parent chain.

## Changes

**Commit 1 — metrics:**
1. New `zkboost_queue_wait_duration_seconds{proof_type}` — an `Instant` stamped into `WorkerInput` at dispatch, observed at dequeue. Long-tail buckets (`0.05s … 900s`): backlogs of minutes are exactly what this metric exists to expose.
2. `zkboost_witness_fetch_duration_seconds` bucket fix — the default buckets end at 10.0, hiding successful 10–12s fetches in `+Inf` despite the slot-aligned witness timeout; now the same 0.5s-step bounds to 12.0 as the prove histogram.

**Commit 2 — self-describing completions + span identity:**

3. `ProofComplete` gains **optional** `witness_ms` / `queue_wait_ms` / `prove_ms` (`Option<u64>` + `#[serde(default)]`). The three stages exactly partition the request lifecycle: admission → witness available → dequeue → done. Absence means *unknown, not zero* — old producers and replayed cache entries (which hold only proof bytes) send `None`. Producers and consumers can upgrade in either order; serde-compat tests cover both directions plus a populated round trip.
4. Identity attributes on stage spans: `new_payload_request_root` on `request_proof` and `prove`; `block_hash` on `fetch_witness` (the witness service is keyed by execution block hash and serves all requests for that block, so the hash is its identity).

**Commit 3 — the same fields on failures:**

5. `ProofFailure` gains the same optional trio, with one semantic addition: on failures, `None` also means *the stage never ran*, so the populated/absent shape locates how far a request got before dying — a witness-timeout failure carries only `witness_ms`; a proving-timeout carries all three with `prove_ms` = the exhausted budget; an admission-time rejection carries none. Timings are threaded to each failure site via a small all-`None`-default `StageTimings` carrier. Replayed failures keep their timings for free (the failure cache stores the whole event). Without this, stage data would exist only for successes — while failures are the primary subjects of stage-attribution analysis.

## Notes

- No behavior change — measurement and event enrichment only; existing consumers are unaffected (unknown JSON keys are ignored, no `deny_unknown_fields` anywhere on this path).
- `cargo fmt` / `clippy --all-targets --locked -- -D warnings` / `cargo test --locked` (80 passed) all clean.
- With this, `witness + queue_wait + prove ≈ request_proof` closes arithmetically, per-request stage data arrives with completion **and failure** events instead of being polled, and every stage span self-identifies in trace UIs.