### PR TITLE
normalize fork labels against the EL chain config

### DIFF
--- a/crates/mock-zkattestor/src/chain_config.rs
+++ b/crates/mock-zkattestor/src/chain_config.rs
@@ -54,6 +54,12 @@ impl ChainConfigResolver {
             }
         }
 
+        if spec.blob_schedule.len() > 2 {
+            tracing::warn!(
+                entries = spec.blob_schedule.len(),
+                "blob schedule has more entries than wire BPO forks; ignoring the extras"
+            );
+        }
         for (index, entry) in spec.blob_schedule.iter().enumerate() {
             if let Some(fork) = bpo_fork(index) {
                 forks.push(ScheduledFork {

--- a/crates/server/src/el_client.rs
+++ b/crates/server/src/el_client.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use url::Url;
 use zkboost_types::Hash256;
 
+use crate::fork_schedule::ElChainConfig;
+
 /// Execution layer JSON-RPC client.
 #[derive(Debug)]
 pub struct ElClient {
@@ -77,6 +79,14 @@ impl ElClient {
     ) -> Result<Option<(ExecutionWitness, usize)>, Error> {
         self.request("debug_executionWitnessByBlockHash", (block_hash,))
             .await
+    }
+
+    /// Fetch the chain configuration (fork activation times) via `debug_chainConfig`.
+    pub(crate) async fn get_chain_config(&self) -> Result<Option<ElChainConfig>, Error> {
+        Ok(self
+            .request::<_, ElChainConfig>("debug_chainConfig", [(); 0])
+            .await?
+            .map(|(config, _)| config))
     }
 }
 

--- a/crates/server/src/fork_schedule.rs
+++ b/crates/server/src/fork_schedule.rs
@@ -1,0 +1,263 @@
+//! Resolution of the active protocol fork from the execution layer's chain config.
+//!
+//! A clientless requester derives its fork label from the Beacon API, whose
+//! `BLOB_SCHEDULE` reports the effective per-epoch parameters and collapses
+//! same-epoch entries into the winning one. On networks that activate several
+//! BPO forks at the same epoch (a common devnet shape) the requester cannot
+//! recover the execution layer's fork naming from that view and may mislabel
+//! e.g. BPO2 as BPO1. The guest maps the fork label to that fork's blob
+//! parameters, so a mislabel would prove the block under the wrong blob rules.
+//!
+//! This module resolves the fork actually active on the execution layer at a
+//! payload timestamp so the request handler can correct such labels against
+//! EL ground truth before proving.
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use anyhow::Context;
+use serde::Deserialize;
+use tokio::sync::OnceCell;
+use tracing::warn;
+use zkboost_types::ProtocolFork;
+
+use crate::el_client::ElClient;
+
+/// Upper bound on the lazy chain-config fetch, so an unresponsive EL degrades
+/// to the warn-and-skip path instead of stalling proof requests.
+const EL_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Chain identity and fork activation times extracted from the EL's
+/// `debug_chainConfig` response.
+///
+/// Only the timestamp-scheduled forks a stateless input can name are modeled;
+/// forks the EL does not schedule are absent. Unrecognized fields are kept
+/// aside so a fork-time key newer than this model can be detected.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub(crate) struct ElChainConfig {
+    chain_id: Option<u64>,
+    shanghai_time: Option<u64>,
+    cancun_time: Option<u64>,
+    prague_time: Option<u64>,
+    osaka_time: Option<u64>,
+    bpo1_time: Option<u64>,
+    bpo2_time: Option<u64>,
+    amsterdam_time: Option<u64>,
+    #[serde(flatten)]
+    extra: HashMap<String, serde_json::Value>,
+}
+
+/// Returns the EL activation time for a fork, or `None` for forks scheduled by
+/// block number or total difficulty rather than timestamp.
+///
+/// Deliberately wildcard-free: when the upstream [`ProtocolFork`] enum gains a
+/// variant (a new fork or BPO), this match stops compiling, forcing an
+/// explicit arm. The schedule is built by enumerating every discriminant
+/// through the upstream `ProtocolFork::from_u8` decoder and this match, so no
+/// fork list exists in this crate to fall out of sync. An arm added without a
+/// matching [`ElChainConfig`] field leaves that fork's `*Time` key
+/// unrecognized, which the unknown-key guard turns into disabled resolution
+/// rather than a wrong schedule.
+fn activation_time(config: &ElChainConfig, fork: ProtocolFork) -> Option<u64> {
+    use ProtocolFork::*;
+    match fork {
+        Frontier | Homestead | DAOFork | TangerineWhistle | SpuriousDragon | Byzantium
+        | StPetersburg | Istanbul | MuirGlacier | Berlin | London | ArrowGlacier | GrayGlacier
+        | Paris => None,
+        Shanghai => config.shanghai_time,
+        Cancun => config.cancun_time,
+        Prague => config.prague_time,
+        Osaka => config.osaka_time,
+        BPO1 => config.bpo1_time,
+        BPO2 => config.bpo2_time,
+        Amsterdam => config.amsterdam_time,
+    }
+}
+
+/// The EL's chain id and fork schedule as `(activation timestamp, fork)` pairs.
+#[derive(Debug, Clone)]
+pub(crate) struct ForkSchedule {
+    chain_id: Option<u64>,
+    forks: Vec<(u64, ProtocolFork)>,
+    /// Fork-time keys in the EL config that this model does not recognize
+    /// (e.g. `bpo3Time` from an EL newer than this binary). A non-empty list
+    /// means the schedule is incomplete and resolution is disabled.
+    unknown_fork_times: Vec<String>,
+}
+
+impl ForkSchedule {
+    /// Builds the schedule from the EL chain config's activation times.
+    pub(crate) fn new(config: &ElChainConfig) -> Self {
+        let forks = (u8::MIN..=u8::MAX)
+            .filter_map(ProtocolFork::from_u8)
+            .filter_map(|fork| activation_time(config, fork).map(|time| (time, fork)))
+            .collect();
+        let unknown_fork_times: Vec<String> = config
+            .extra
+            .keys()
+            .filter(|key| key.ends_with("Time"))
+            .cloned()
+            .collect();
+        if !unknown_fork_times.is_empty() {
+            warn!(
+                keys = ?unknown_fork_times,
+                "EL chain config schedules forks unknown to this build; fork normalization disabled"
+            );
+        }
+        Self {
+            chain_id: config.chain_id,
+            forks,
+            unknown_fork_times,
+        }
+    }
+
+    /// Returns the EL's chain id when the config reported one.
+    pub(crate) fn chain_id(&self) -> Option<u64> {
+        self.chain_id
+    }
+
+    /// Resolves the fork active at an execution timestamp, returning it with
+    /// its activation timestamp.
+    ///
+    /// Forks activating at the same instant shadow each other and the latest
+    /// one wins, matching how the execution layer applies its schedule.
+    /// Returns `None` when the EL schedules forks this build does not know:
+    /// resolving against an incomplete model could normalize a correct label
+    /// to a stale fork.
+    pub(crate) fn resolve(&self, timestamp: u64) -> Option<(ProtocolFork, u64)> {
+        if !self.unknown_fork_times.is_empty() {
+            return None;
+        }
+        self.forks
+            .iter()
+            .filter(|(activation, _)| *activation <= timestamp)
+            .max_by_key(|(activation, fork)| (*activation, *fork))
+            .map(|(activation, fork)| (*fork, *activation))
+    }
+}
+
+/// Lazily fetched, cached [`ForkSchedule`].
+///
+/// The schedule is fetched from the EL on first use so the server does not
+/// depend on the EL being reachable at startup. A failed fetch is logged,
+/// resolution is skipped for that request, and the fetch is retried on the
+/// next one.
+#[derive(Debug)]
+pub(crate) struct ForkScheduleCache {
+    el_client: Arc<ElClient>,
+    schedule: OnceCell<ForkSchedule>,
+}
+
+impl ForkScheduleCache {
+    /// Creates an empty cache backed by the given EL client.
+    pub(crate) fn new(el_client: Arc<ElClient>) -> Self {
+        Self {
+            el_client,
+            schedule: OnceCell::new(),
+        }
+    }
+
+    /// Creates a cache pre-populated with a schedule, bypassing the EL fetch.
+    #[cfg(test)]
+    pub(crate) fn preset(schedule: ForkSchedule) -> Self {
+        let el_client = ElClient::new(
+            url::Url::parse("http://127.0.0.1:0/").unwrap(),
+            reqwest::header::HeaderMap::new(),
+        )
+        .unwrap();
+        Self {
+            el_client: Arc::new(el_client),
+            schedule: OnceCell::new_with(Some(schedule)),
+        }
+    }
+
+    /// Returns the schedule, fetching it from the EL on first use.
+    pub(crate) async fn get(&self) -> Option<&ForkSchedule> {
+        self.schedule
+            .get_or_try_init(|| async {
+                let config = tokio::time::timeout(EL_FETCH_TIMEOUT, self.el_client.get_chain_config())
+                    .await
+                    .context("fetch EL chain config timed out")?
+                    .context("fetch EL chain config")?
+                    .context("EL returned no chain config")?;
+                Ok::<_, anyhow::Error>(ForkSchedule::new(&config))
+            })
+            .await
+            .map_err(
+                |error| warn!(%error, "failed to fetch EL chain config; skipping fork normalization"),
+            )
+            .ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zkboost_types::ProtocolFork;
+
+    use super::{ElChainConfig, ForkSchedule};
+
+    fn config_from(value: serde_json::Value) -> ElChainConfig {
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn resolves_latest_fork_when_activations_share_a_timestamp() {
+        // Devnet shape: every fork including both BPOs activates at genesis.
+        let config = config_from(serde_json::json!({
+            "chainId": 3151908,
+            "shanghaiTime": 0,
+            "cancunTime": 0,
+            "pragueTime": 0,
+            "osakaTime": 0,
+            "bpo1Time": 0,
+            "bpo2Time": 0,
+        }));
+        let schedule = ForkSchedule::new(&config);
+        assert_eq!(schedule.resolve(1_000), Some((ProtocolFork::BPO2, 0)));
+        assert_eq!(schedule.chain_id(), Some(3151908));
+    }
+
+    #[test]
+    fn resolves_by_activation_time() {
+        let config = config_from(serde_json::json!({
+            "cancunTime": 0,
+            "pragueTime": 100,
+            "osakaTime": 200,
+            "bpo1Time": 300,
+            "bpo2Time": 400,
+        }));
+        let schedule = ForkSchedule::new(&config);
+        assert_eq!(schedule.resolve(0), Some((ProtocolFork::Cancun, 0)));
+        assert_eq!(schedule.resolve(299), Some((ProtocolFork::Osaka, 200)));
+        assert_eq!(schedule.resolve(300), Some((ProtocolFork::BPO1, 300)));
+        assert_eq!(schedule.resolve(1_000), Some((ProtocolFork::BPO2, 400)));
+    }
+
+    #[test]
+    fn resolves_none_before_first_activation() {
+        let config = config_from(serde_json::json!({ "osakaTime": 100 }));
+        assert_eq!(ForkSchedule::new(&config).resolve(99), None);
+    }
+
+    #[test]
+    fn resolves_none_when_no_fork_is_scheduled() {
+        let config = config_from(serde_json::json!({}));
+        assert_eq!(ForkSchedule::new(&config).resolve(u64::MAX), None);
+    }
+
+    #[test]
+    fn disables_resolution_when_el_schedules_unknown_forks() {
+        // An EL newer than this build scheduling e.g. bpo3: resolving against
+        // the incomplete model could normalize a correct BPO3 label back to
+        // BPO2, so resolution is disabled entirely (chain id checks remain).
+        let config = config_from(serde_json::json!({
+            "chainId": 1,
+            "bpo1Time": 0,
+            "bpo2Time": 0,
+            "bpo3Time": 0,
+        }));
+        let schedule = ForkSchedule::new(&config);
+        assert_eq!(schedule.resolve(1_000), None);
+        assert_eq!(schedule.chain_id(), Some(1));
+    }
+}

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -20,6 +20,7 @@ use zkboost_types::{Hash256, ProofEvent, ProofType};
 
 use crate::{
     dashboard::{DashboardEvent, DashboardState},
+    fork_schedule::ForkScheduleCache,
     metrics::http_metrics_middleware,
     proof::{FailureCache, ProofServiceMessage, zkvm::zkVMInstance},
 };
@@ -34,6 +35,7 @@ pub(crate) struct AppState {
     pub(crate) failure_cache: FailureCache,
     pub(crate) metrics: PrometheusHandle,
     pub(crate) dashboard: Option<Arc<RwLock<DashboardState>>>,
+    pub(crate) fork_schedule: Option<Arc<ForkScheduleCache>>,
     pub(crate) proof_service_tx: mpsc::Sender<ProofServiceMessage>,
     pub(crate) proof_event_rx: broadcast::Receiver<ProofEvent>,
     pub(crate) dashboard_event_rx: broadcast::Receiver<DashboardEvent>,
@@ -48,6 +50,7 @@ impl AppState {
         failure_cache: FailureCache,
         metrics: PrometheusHandle,
         dashboard: Option<Arc<RwLock<DashboardState>>>,
+        fork_schedule: Option<Arc<ForkScheduleCache>>,
         proof_service_tx: mpsc::Sender<ProofServiceMessage>,
         proof_event_rx: broadcast::Receiver<ProofEvent>,
         dashboard_event_rx: broadcast::Receiver<DashboardEvent>,
@@ -58,6 +61,7 @@ impl AppState {
             failure_cache,
             metrics,
             dashboard,
+            fork_schedule,
             proof_service_tx,
             proof_event_rx,
             dashboard_event_rx,
@@ -163,11 +167,21 @@ pub(crate) mod tests {
     use crate::{
         config::{MockProvingTime, zkVMConfig},
         dashboard::DashboardState,
+        fork_schedule::ForkScheduleCache,
         http::{AppState, router},
-        proof::zkvm::zkVMInstance,
+        proof::{ProofServiceMessage, zkvm::zkVMInstance},
     };
 
     pub(crate) async fn mock_app_state() -> Arc<AppState> {
+        let (state, _) = mock_app_state_with(None).await;
+        state
+    }
+
+    /// Builds mock state with an optional fork schedule, returning the proof
+    /// service receiver so tests can observe enqueued messages.
+    pub(crate) async fn mock_app_state_with(
+        fork_schedule: Option<Arc<ForkScheduleCache>>,
+    ) -> (Arc<AppState>, mpsc::Receiver<ProofServiceMessage>) {
         let proof_type = ProofType::RethZisk;
         let mock_config = zkVMConfig::Mock {
             proof_type,
@@ -185,20 +199,22 @@ pub(crate) mod tests {
         let metrics = PrometheusBuilder::new().build_recorder().handle();
         let dashboard = Arc::new(RwLock::new(DashboardState::new(vec![proof_type], 256))).into();
 
-        let (proof_service_tx, _) = mpsc::channel(16);
+        let (proof_service_tx, proof_service_rx) = mpsc::channel(16);
         let (_, proof_event_rx) = broadcast::channel(16);
         let (_, dashboard_event_rx) = broadcast::channel(16);
 
-        Arc::new(AppState::new(
+        let state = Arc::new(AppState::new(
             zkvms,
             proof_cache,
             failure_cache,
             metrics,
             dashboard,
+            fork_schedule,
             proof_service_tx,
             proof_event_rx,
             dashboard_event_rx,
-        ))
+        ));
+        (state, proof_service_rx)
     }
 
     #[tokio::test]

--- a/crates/server/src/http/v1/post_execution_proof_requests.rs
+++ b/crates/server/src/http/v1/post_execution_proof_requests.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use axum::{Json, extract::State};
 use bytes::Bytes;
-use tracing::{debug, info_span, instrument};
+use tracing::{debug, info, info_span, instrument};
 use zkboost_types::{
     Hash256, HashTreeRoot, NewPayloadRequest, ProofRequestBody, ProofRequestResponse, ProtocolFork,
     Sha2Hasher, SszDecode,
@@ -67,6 +67,52 @@ pub(crate) async fn post_execution_proof_requests(
         }
     }
 
+    // A clientless requester labels the fork from the Beacon API, which cannot
+    // distinguish BPO forks that activate at the same epoch (their schedule
+    // entries collapse into the effective one). Since the guest maps the label
+    // to that fork's blob parameters, resolve the fork actually active on the
+    // EL at the payload timestamp and correct compatible mislabels; a label
+    // whose input schema disagrees with the EL's active fork is rejected. The
+    // same chain-config response carries the EL's chain id, checked against
+    // the request's first: a mismatch is rejected before proving resources
+    // are spent.
+    //
+    // Only the label is rewritten. The submitted chain config is passed through
+    // untouched because the guest echoes it into the proof's public values, and
+    // the requester later reconstructs those values from its own copy when
+    // verifying — the label itself is not part of the public values.
+    let mut fork = request.fork;
+    if let Some(cache) = &state.fork_schedule
+        && let Some(schedule) = cache.get().await
+    {
+        if let Some(el_chain_id) = schedule.chain_id()
+            && el_chain_id != request.chain_config.chain_id
+        {
+            return Err(ErrorResponse::bad_request(format!(
+                "chain_config.chain_id {} does not match the execution layer's chain id {el_chain_id}",
+                request.chain_config.chain_id
+            )));
+        }
+        if let Some((el_fork, _)) = schedule.resolve(request.new_payload_request.timestamp())
+            && el_fork != fork
+        {
+            if !is_valid_payload_variant(el_fork, &request.new_payload_request) {
+                return Err(ErrorResponse::bad_request(format!(
+                    "submitted fork {fork:?} does not match fork {el_fork:?} active on the execution layer at the payload timestamp"
+                )));
+            }
+            // Info, not warn: on networks whose Beacon API collapses the
+            // schedule the requester can never derive the right label, so
+            // this fires on every request in steady state.
+            info!(
+                submitted = ?fork,
+                resolved = ?el_fork,
+                "normalized fork label to the execution layer's active fork"
+            );
+            fork = el_fork;
+        }
+    }
+
     let new_payload_request = Arc::new(request.new_payload_request);
     let new_payload_request_root = Hash256::from(new_payload_request.hash_tree_root(&Sha2Hasher));
     let block_number = new_payload_request.block_number();
@@ -84,7 +130,7 @@ pub(crate) async fn post_execution_proof_requests(
     state
         .proof_service_tx
         .send(ProofServiceMessage::RequestProof {
-            fork: request.fork,
+            fork,
             new_payload_request_root,
             new_payload_request,
             chain_config: request.chain_config,
@@ -106,17 +152,24 @@ pub(crate) async fn post_execution_proof_requests(
 ///
 /// A mismatch makes the guest reject the input and return a default result, which the prover
 /// still turns into a valid proof of that empty result, so the request is refused here instead.
+///
+/// Deliberately wildcard-free on the fork side: when the upstream [`ProtocolFork`] enum gains
+/// a variant, this match stops compiling, forcing the schema assignment to be made explicitly.
 fn is_valid_payload_variant(fork: ProtocolFork, new_payload_request: &NewPayloadRequest) -> bool {
     use NewPayloadRequest::*;
     use ProtocolFork::*;
-    matches!(
-        (fork, new_payload_request),
-        (Paris, Bellatrix(_))
-            | (Shanghai, Capella(_))
-            | (Cancun, Deneb(_))
-            | (Prague | Osaka | BPO1 | BPO2, ElectraFulu(_))
-            | (Amsterdam, Gloas(_))
-    )
+    match fork {
+        // Pre-merge forks have no execution payload schema.
+        Frontier | Homestead | DAOFork | TangerineWhistle | SpuriousDragon | Byzantium
+        | StPetersburg | Istanbul | MuirGlacier | Berlin | London | ArrowGlacier | GrayGlacier => {
+            false
+        }
+        Paris => matches!(new_payload_request, Bellatrix(_)),
+        Shanghai => matches!(new_payload_request, Capella(_)),
+        Cancun => matches!(new_payload_request, Deneb(_)),
+        Prague | Osaka | BPO1 | BPO2 => matches!(new_payload_request, ElectraFulu(_)),
+        Amsterdam => matches!(new_payload_request, Gloas(_)),
+    }
 }
 
 #[cfg(test)]
@@ -135,7 +188,15 @@ mod tests {
         ProtocolFork, SszDecode, SszEncode,
     };
 
-    use crate::http::{AppState, tests::mock_app_state, v1::post_execution_proof_requests};
+    use crate::{
+        fork_schedule::{ElChainConfig, ForkSchedule, ForkScheduleCache},
+        http::{
+            AppState,
+            tests::{mock_app_state, mock_app_state_with},
+            v1::post_execution_proof_requests,
+        },
+        proof::ProofServiceMessage,
+    };
 
     const NEW_PAYLOAD_REQUEST: &[u8] =
         include_bytes!("../../../tests/fixture/new_payload_request.ssz");
@@ -145,10 +206,18 @@ mod tests {
     }
 
     fn proof_request_body_with_fork(fork: ProtocolFork, proof_types: Vec<ProofType>) -> Vec<u8> {
+        proof_request_body_with_activation(fork, 0, proof_types)
+    }
+
+    fn proof_request_body_with_activation(
+        fork: ProtocolFork,
+        activation_timestamp: u64,
+        proof_types: Vec<ProofType>,
+    ) -> Vec<u8> {
         let new_payload_request = NewPayloadRequest::from_ssz_bytes(NEW_PAYLOAD_REQUEST).unwrap();
         let chain_config = ChainConfig {
             chain_id: 1,
-            active_fork: ForkConfig::new(ForkActivation::new(None, Some(0))),
+            active_fork: ForkConfig::new(ForkActivation::new(None, Some(activation_timestamp))),
         };
         ProofRequestBody {
             fork,
@@ -206,6 +275,135 @@ mod tests {
     async fn test_fork_invalid_payload_variant_returns_bad_request() {
         let body = proof_request_body_with_fork(ProtocolFork::Cancun, vec![ProofType::RethZisk]);
         assert_eq!(send(mock_app_state().await, body).await, 400);
+    }
+
+    fn schedule_from(value: serde_json::Value) -> Arc<ForkScheduleCache> {
+        let config: ElChainConfig = serde_json::from_value(value).unwrap();
+        Arc::new(ForkScheduleCache::preset(ForkSchedule::new(&config)))
+    }
+
+    /// Devnet shape: BPO1 and BPO2 both activate at genesis, so a requester
+    /// working from the Beacon API's collapsed blob schedule labels the
+    /// active fork BPO1 while the EL's effective fork is BPO2. The chain id
+    /// matches the test fixture's.
+    fn devnet_schedule() -> Arc<ForkScheduleCache> {
+        schedule_from(serde_json::json!({
+            "chainId": 1,
+            "shanghaiTime": 0,
+            "cancunTime": 0,
+            "pragueTime": 0,
+            "osakaTime": 0,
+            "bpo1Time": 0,
+            "bpo2Time": 0,
+        }))
+    }
+
+    #[tokio::test]
+    async fn test_mislabeled_bpo_fork_is_normalized_against_el_schedule() {
+        let (state, mut proof_service_rx) = mock_app_state_with(Some(devnet_schedule())).await;
+        // The requester's own activation timestamp (7) deliberately differs
+        // from the EL's (0): only the label may be rewritten, never the
+        // chain config, which the guest echoes into the proof's public values
+        // that the requester later verifies against.
+        let body =
+            proof_request_body_with_activation(ProtocolFork::BPO1, 7, vec![ProofType::RethZisk]);
+
+        assert_eq!(send(state, body).await, 200);
+
+        let message = proof_service_rx.recv().await.unwrap();
+        let ProofServiceMessage::RequestProof {
+            fork, chain_config, ..
+        } = message
+        else {
+            panic!("expected a RequestProof message");
+        };
+        assert_eq!(fork, ProtocolFork::BPO2);
+        assert_eq!(chain_config.chain_id, 1);
+        assert_eq!(chain_config.active_fork.activation.timestamp(), Some(7));
+    }
+
+    #[tokio::test]
+    async fn test_unknown_el_fork_time_disables_normalization() {
+        // The EL schedules a fork this build does not model: resolution is
+        // disabled, so the submitted label passes through unrewritten and the
+        // request still succeeds.
+        let schedule = schedule_from(serde_json::json!({
+            "chainId": 1,
+            "bpo1Time": 0,
+            "bpo2Time": 0,
+            "bpo3Time": 0,
+        }));
+        let (state, mut proof_service_rx) = mock_app_state_with(Some(schedule)).await;
+        let body = proof_request_body_with_fork(ProtocolFork::BPO1, vec![ProofType::RethZisk]);
+
+        assert_eq!(send(state, body).await, 200);
+
+        let message = proof_service_rx.recv().await.unwrap();
+        let ProofServiceMessage::RequestProof { fork, .. } = message else {
+            panic!("expected a RequestProof message");
+        };
+        assert_eq!(fork, ProtocolFork::BPO1);
+    }
+
+    #[tokio::test]
+    async fn test_unreachable_el_degrades_to_passthrough() {
+        // A schedule cache whose EL fetch fails leaves normalization off; the
+        // request succeeds with the submitted label.
+        let cache = Arc::new(ForkScheduleCache::new(Arc::new(
+            crate::el_client::ElClient::new(
+                url::Url::parse("http://127.0.0.1:1/").unwrap(),
+                reqwest::header::HeaderMap::new(),
+            )
+            .unwrap(),
+        )));
+        let (state, mut proof_service_rx) = mock_app_state_with(Some(cache)).await;
+        let body = proof_request_body_with_fork(ProtocolFork::BPO1, vec![ProofType::RethZisk]);
+
+        assert_eq!(send(state, body).await, 200);
+
+        let message = proof_service_rx.recv().await.unwrap();
+        let ProofServiceMessage::RequestProof { fork, .. } = message else {
+            panic!("expected a RequestProof message");
+        };
+        assert_eq!(fork, ProtocolFork::BPO1);
+    }
+
+    #[tokio::test]
+    async fn test_mismatched_chain_id_returns_bad_request() {
+        let schedule = schedule_from(serde_json::json!({
+            "chainId": 999,
+            "bpo1Time": 0,
+            "bpo2Time": 0,
+        }));
+        let (state, _proof_service_rx) = mock_app_state_with(Some(schedule)).await;
+        let body = proof_request_body_with_fork(ProtocolFork::BPO2, vec![ProofType::RethZisk]);
+
+        assert_eq!(send(state, body).await, 400);
+    }
+
+    #[tokio::test]
+    async fn test_matching_fork_label_is_not_rewritten() {
+        let (state, mut proof_service_rx) = mock_app_state_with(Some(devnet_schedule())).await;
+        let body = proof_request_body_with_fork(ProtocolFork::BPO2, vec![ProofType::RethZisk]);
+
+        assert_eq!(send(state, body).await, 200);
+
+        let message = proof_service_rx.recv().await.unwrap();
+        let ProofServiceMessage::RequestProof { fork, .. } = message else {
+            panic!("expected a RequestProof message");
+        };
+        assert_eq!(fork, ProtocolFork::BPO2);
+    }
+
+    #[tokio::test]
+    async fn test_fork_conflicting_with_el_schedule_returns_bad_request() {
+        // The EL only schedules Cancun, whose payload schema differs from the
+        // ElectraFulu payload submitted under a BPO2 label.
+        let schedule = schedule_from(serde_json::json!({ "cancunTime": 0 }));
+        let (state, _proof_service_rx) = mock_app_state_with(Some(schedule)).await;
+        let body = proof_request_body_with_fork(ProtocolFork::BPO2, vec![ProofType::RethZisk]);
+
+        assert_eq!(send(state, body).await, 400);
     }
 
     #[tokio::test]

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod config;
 pub(crate) mod dashboard;
 pub mod el_client;
+pub(crate) mod fork_schedule;
 pub mod http;
 pub mod metrics;
 #[cfg(feature = "otel")]

--- a/crates/server/src/server.rs
+++ b/crates/server/src/server.rs
@@ -26,6 +26,7 @@ use crate::{
     config::Config,
     dashboard::{DashboardService, DashboardState},
     el_client::ElClient,
+    fork_schedule::ForkScheduleCache,
     http::{AppState, router},
     metrics::{set_build_info, set_programs_loaded},
     proof::{ProofService, worker, zkvm::zkVMInstance},
@@ -114,6 +115,7 @@ impl zkBoostServer {
 
         let mut handles = Vec::new();
 
+        let fork_schedule = Arc::new(ForkScheduleCache::new(self.el_client.clone()));
         let witness_service = WitnessService::new(
             self.el_client,
             proof_service_tx.clone(),
@@ -185,6 +187,7 @@ impl zkBoostServer {
             failure_cache,
             self.metrics,
             dashboard,
+            Some(fork_schedule),
             proof_service_tx,
             proof_event_rx,
             dashboard_event_rx,


### PR DESCRIPTION
## Problem

A clientless requester (mock-zkattestor, proofessoor) derives its fork label from the
Beacon API. The spec's `BLOB_SCHEDULE` reports effective per-epoch parameters with no
fork names, and collapses same-epoch entries into the winning one — mainnet serves two
distinct-epoch entries (BPO1 @ 412672, BPO2 @ 419072) so positional labeling works
there, but a devnet activating BPO1 and BPO2 both at genesis (the ethpandaops default
since [ethpandaops/ethereum-package#1468](https://github.com/ethpandaops/ethereum-package/pull/1468)) serves one merged `{epoch 0, max 21}` entry.
The requester cannot recover the EL's naming from that view — the information never
crosses the Beacon API — so it labels the effective BPO2 fork as BPO1.

Since ere-guests v0.14 the guest maps the fork label to that fork's blob parameters
(`active_fork_blob_schedule`: BPO1 → max 15, BPO2 → max 21), so a mislabeled request
**proves the block under the wrong blob rules with no error raised**. Pre-v0.14
servers rejected the same mislabel loudly (`blob max mismatch for BPO1`); v0.14
removed that check, turning a loud failure into a silent one.

## Fix

The server corrects labels against EL ground truth, which it alone can see:

- `fork_schedule.rs` (new): fetches `debug_chainConfig` lazily on the first proof
  request (5s timeout, cached; a failed fetch logs a warning, skips normalization,
  and retries on the next request) and resolves the fork in force at any payload
  timestamp, tie-breaking same-instant activations the way the EL applies its own
  schedule (latest wins).
- In `post_execution_proof_requests`: a submitted label that differs from the
  EL-resolved fork but shares its input schema (Prague/Osaka/BPO1/BPO2 →
  `ElectraFulu`) is rewritten, logged at info. A label whose schema conflicts with
  the EL's active fork is rejected with a 400, as is a chain-id mismatch — both
  before witness fetching or proving spend anything.
- **Only the label is rewritten.** The submitted chain config passes through
  untouched: the guest echoes it into the proof's public values, which the requester
  reconstructs from its own copy at verification — rewriting any part of it would
  fail every requester-side verification. The label is not part of the public
  values, so rewriting it is verification-invisible while steering the guest to the
  correct blob parameters.
- Servers whose EL cannot serve `debug_chainConfig` keep today's behavior
  (trust the label), with a warning.

## Future-proofing

- The schedule is built by enumerating every `ProtocolFork` discriminant through the
  upstream `from_u8` decoder and a wildcard-free match — a dependency bump that
  the enum fails compilation here, and no fork list exists in this crate to fall out
  of sync. `is_valid_payload_variant` is likewise wildcard-free on the fork side
- If the EL reports a fork-time key this build does not model (e.g. `bpo3Time` from a
  newer EL), the schedule is treated as incomplete and normalization disables it
  with a warning instead of resolving against a stale model.
- mock-zkattestor now warns when the blob schedule has more entries than the wir
  BPO forks can express, matching proofessoor.

## Testing

- Resolver unit tests: same-instant shadowing (devnet shape → BPO2), distinct-time
  ordering, pre-activation/empty-schedule `None`, chain-id capture, unknown-fork
  disable.
- Handler tests: mislabeled BPO1 normalized to BPO2 with the requester's chain c
  passed through unchanged; matching labels not rewritten; schema conflicts and
  chain-id mismatches 400; unknown EL fork times and an unreachable EL both degr
  to label passthrough with the request still succeeding.
- 66 lib + 5 integration tests pass; workspace clippy clean.
- Live end-to-end on an ethpandaops devnet (lighthouse/reth, BPO1+BPO2 at genesis,
  collapsed Beacon API schedule): both mock-zkattestor and a v0.14-migrated
  proofessoor show `normalized fork label … submitted=BPO1 resolved=BPO2` per block,
  and every proof completes **and verifies** — the requester's CL-derived activa
  differs from the EL's, confirming the label-only design keeps the verification
  round-trip intact.

## Notes

- The verification endpoint is untouched: proofs are generated under normalized
  labels, verification ignores the submitted fork field, and public values carry the
  requester's own chain config.
- The schedule is cached for the process lifetime; an EL redeployed with a different
  genesis needs a server restart (the chain-id check catches cross-network swaps
- A chain scheduling BPO3+ is out of reach for the whole pipeline today
  (`ProtocolFork` has no BPO3 variant); the unknown-fork guard makes this server
  safe rather than mislabel when that day comes.
- **Release ordering:** this should merge ahead of the pending release-please 0.
  PR, so the first v0.14-line release ships with normalization — cut from current
  master, 0.10.0 would silently mis-prove on collapsed-schedule devnets until a
  follow-up release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)  